### PR TITLE
Type safety fix

### DIFF
--- a/lib/techniques.ts
+++ b/lib/techniques.ts
@@ -3,6 +3,7 @@
 import prisma from "./prisma";
 import { revalidatePath } from "next/cache";
 import { validateTechniqueData } from "./validation";
+import type { Technique } from "../app/generated/prisma/client";
 
 export async function getTechniques() {
   try {
@@ -48,7 +49,7 @@ export async function createTechniqueAction(
   prevState: {
     success: boolean;
     error: string | null;
-    technique: any;
+    technique: Technique | null;
   } | null,
   formData: FormData
 ) {

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -4,7 +4,7 @@ export interface ValidatedTechniqueData {
   name: string;
   type: TechniqueType;
   name_hiragana: string | null;
-  name_kanji: string | null
+  name_kanji: string | null;
   description: string | null;
 }
 
@@ -16,7 +16,7 @@ export function validateTechniqueData(formData: FormData): ValidatedTechniqueDat
   const name = nameValue.trim().toLowerCase();
 
   const typeValue = formData.get("tech_type");
-  if (!typeValue || typeof typeValue !== "string" || typeValue === "") {
+  if (!typeValue || typeof typeValue !== "string" || typeValue.trim() === "") {
     throw new Error("Technique type is required");
   }
   if (!Object.values(TechniqueType).includes(typeValue as TechniqueType)) {

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,55 @@
+import { TechniqueType } from "../app/generated/prisma/client";
+
+export interface ValidatedTechniqueData {
+  name: string;
+  type: TechniqueType;
+  name_hiragana: string | null;
+  name_kanji: string | null
+  description: string | null;
+}
+
+export function validateTechniqueData(formData: FormData): ValidatedTechniqueData {
+  const nameValue = formData.get("tech_name");
+  if (!nameValue || typeof nameValue !== "string" || nameValue.trim() === "") {
+    throw new Error("Technique name is required");
+  }
+  const name = nameValue.trim().toLowerCase();
+
+  const typeValue = formData.get("tech_type");
+  if (!typeValue || typeof typeValue !== "string" || typeValue === "") {
+    throw new Error("Technique type is required");
+  }
+  if (!Object.values(TechniqueType).includes(typeValue as TechniqueType)) {
+    throw new Error(
+      `Invalid technique type. Must be one of: ${Object.values(TechniqueType).join(", ")}`
+    );
+  }
+  const type = typeValue as TechniqueType;
+
+  // Validate optional fields - ensure they're strings, not File objects
+  const hiraganaValue = formData.get("name_hiragana");
+  const name_hiragana =
+    hiraganaValue && typeof hiraganaValue === "string" && hiraganaValue.trim()
+      ? hiraganaValue.trim()
+      : null;
+
+  const kanjiValue = formData.get("name_kanji");
+  const name_kanji =
+    kanjiValue && typeof kanjiValue === "string" && kanjiValue.trim()
+      ? kanjiValue.trim()
+      : null;
+
+  const descriptionValue = formData.get("tech_description");
+  const description =
+    descriptionValue && typeof descriptionValue === "string" && descriptionValue.trim()
+      ? descriptionValue.trim()
+      : null;
+
+  return {
+    name,
+    type,
+    name_hiragana,
+    name_kanji,
+    description,
+  };
+}


### PR DESCRIPTION
  Refactor technique form validation with type-safe validation function
  - Extract FormData validation logic into dedicated `lib/validation.ts` module
  - Replace unsafe type assertions with runtime validation
  - Add proper TypeScript types throughout (removed `any` types)
  - Validate FormData fields against Prisma schema (TechniqueType enum, required fields, string vs File checks)

