### PR TITLE
Sync versions of prisma and prisma client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "kata-db",
       "version": "0.1.0",
       "dependencies": {
-        "@prisma/adapter-pg": "^7.2.0",
-        "@prisma/client": "^7.2.0",
+        "@prisma/adapter-pg": "7.3.0",
+        "@prisma/client": "7.3.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-label": "^2.1.8",
@@ -33,7 +33,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
-        "prisma": "^7.2.0",
+        "prisma": "7.3.0",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "tw-animate-css": "^1.4.0",
@@ -1820,23 +1820,23 @@
       }
     },
     "node_modules/@prisma/adapter-pg": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.2.0.tgz",
-      "integrity": "sha512-euIdQ13cRB2wZ3jPsnDnFhINquo1PYFPCg6yVL8b2rp3EdinQHsX9EDdCtRr489D5uhphcRk463OdQAFlsCr0w==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.3.0.tgz",
+      "integrity": "sha512-iuYQMbIPO6i9O45Fv8TB7vWu00BXhCaNAShenqF7gLExGDbnGp5BfFB4yz1K59zQ59jF6tQ9YHrg0P6/J3OoLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/driver-adapter-utils": "7.2.0",
+        "@prisma/driver-adapter-utils": "7.3.0",
         "pg": "^8.16.3",
         "postgres-array": "3.0.4"
       }
     },
     "node_modules/@prisma/client": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.2.0.tgz",
-      "integrity": "sha512-JdLF8lWZ+LjKGKpBqyAlenxd/kXjd1Abf/xK+6vUA7R7L2Suo6AFTHFRpPSdAKCan9wzdFApsUpSa/F6+t1AtA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.3.0.tgz",
+      "integrity": "sha512-FXBIxirqQfdC6b6HnNgxGmU7ydCPEPk7maHMOduJJfnTP+MuOGa15X4omjR/zpPUUpm8ef/mEFQjJudOGkXFcQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/client-runtime-utils": "7.2.0"
+        "@prisma/client-runtime-utils": "7.3.0"
       },
       "engines": {
         "node": "^20.19 || ^22.12 || >=24.0"
@@ -1855,9 +1855,9 @@
       }
     },
     "node_modules/@prisma/client-runtime-utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.2.0.tgz",
-      "integrity": "sha512-dn7oB53v0tqkB0wBdMuTNFNPdEbfICEUe82Tn9FoKAhJCUkDH+fmyEp0ClciGh+9Hp2Tuu2K52kth2MTLstvmA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.3.0.tgz",
+      "integrity": "sha512-dG/ceD9c+tnXATPk8G+USxxYM9E6UdMTnQeQ+1SZUDxTz7SgQcfxEqafqIQHcjdlcNK/pvmmLfSwAs3s2gYwUw==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/config": {
@@ -1877,6 +1877,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
       "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
@@ -1906,13 +1907,19 @@
       }
     },
     "node_modules/@prisma/driver-adapter-utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.2.0.tgz",
-      "integrity": "sha512-gzrUcbI9VmHS24Uf+0+7DNzdIw7keglJsD5m/MHxQOU68OhGVzlphQRobLiDMn8CHNA2XN8uugwKjudVtnfMVQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.3.0.tgz",
+      "integrity": "sha512-Wdlezh1ck0Rq2dDINkfSkwbR53q53//Eo1vVqVLwtiZ0I6fuWDGNPxwq+SNAIHnsU+FD/m3aIJKevH3vF13U3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.2.0"
+        "@prisma/debug": "7.3.0"
       }
+    },
+    "node_modules/@prisma/driver-adapter-utils/node_modules/@prisma/debug": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.3.0.tgz",
+      "integrity": "sha512-yh/tHhraCzYkffsI1/3a7SHX8tpgbJu1NPnuxS4rEpJdWAUDHUH25F1EDo6PPzirpyLNkgPPZdhojQK804BGtg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "vercel-build": "prisma generate && prisma migrate deploy && next build"
   },
   "dependencies": {
-    "@prisma/adapter-pg": "^7.2.0",
-    "@prisma/client": "^7.2.0",
+    "@prisma/adapter-pg": "7.3.0",
+    "@prisma/client": "7.3.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-label": "^2.1.8",
@@ -35,7 +35,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
-    "prisma": "^7.2.0",
+    "prisma": "7.3.0",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",


### PR DESCRIPTION
Ran into a Build error when deploying latest changes. 
```
  > Build error occurred
  Error: Turbopack build failed with 2 errors:
  ./app/generated/prisma/internal/class.ts:40:33
  Module not found: Can't resolve '@prisma/client/runtime/query_compiler_fast_bg.postgresql.mjs'
  38 |
  39 | config.compilerWasm = {
  > 40 |   getRuntime: async () => await import("@prisma/client/runtime/query_compiler_fast_bg.postgresql.mjs"),
  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  41 |
  42 |   getQueryCompilerWasmModule: async () => {
  43 |     const { wasm } = await import("@prisma/client/runtime/query_compiler_fast_bg.postgresql.wasm-base64.mjs")
```

Turns out the prisma was on v7.3.0 and @prisma/client was on v7.2.0, which caused a version mismatch. 
My previous locally generated prisma files still had `query_compiler_bg.postgresql.wasm-base64.mjs` and didn't have a problem, while the newly deployed had `_fast` which called the Module not found error. 

Fixed by pinning prisma client to the same version as prisma. 