### PR TITLE
Add kata CRUD server actions

### DIFF
--- a/lib/actions/katas.ts
+++ b/lib/actions/katas.ts
@@ -74,3 +74,84 @@ export async function createKataAction(
   }
 
 }
+
+export async function updateKata(id: number, formData: FormData) {
+  try {
+    const validatedKataData = validateKataData(formData);
+
+    const existingKata = await prisma.kata.findUnique({
+      where: { id },
+    });
+
+    if (!existingKata) {
+      throw new Error(`Kata with ID ${id} does not exist`);
+    }
+
+    if (validatedKataData.name !== existingKata.name || validatedKataData.style !== existingKata.style) {
+      const duplicateKata = await prisma.kata.findUnique({
+        where: {
+          style_name: {
+            style: validatedKataData.style,
+            name: validatedKataData.name,
+          },
+        },
+      })
+      if (duplicateKata) {
+        throw new Error(`Kata "${validatedKataData.name}" already exists`);
+      }
+    }
+
+    const updatedKata = await prisma.kata.update({
+      where: { id },
+      data: validatedKataData,
+    });
+
+    return updatedKata;
+  } catch (error) {
+    console.error("Database error", error);
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error("Could not update kata. Check inputs and try again.");
+  }
+}
+
+export async function updateKataAction(
+  prevState: {
+    success: boolean;
+    error: string | null;
+    kata: Kata | null;
+    operation?: string;
+  } | null,
+  formData: FormData,
+) {
+  try {
+    const idValue = formData.get("id");
+
+    if (!idValue || typeof idValue !== "string") {
+      throw new Error("Invalid or missing kata ID");
+    }
+
+    const id = parseInt(idValue, 10);
+
+    if (isNaN(id)) {
+      throw new Error("Invalid kata ID");
+    }
+
+    const kata = await updateKata(id, formData);
+    revalidatePath("/katas");
+    return {
+      success: true,
+      error: null,
+      kata,
+      operation: "update",
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to update kata",
+      kata: null,
+      operation: "update",
+    };
+  }
+}

--- a/lib/actions/katas.ts
+++ b/lib/actions/katas.ts
@@ -1,4 +1,4 @@
-"user server"
+"use server"
 
 import { revalidatePath } from "next/cache";
 import type { Kata } from "@/app/generated/prisma/browser";
@@ -12,6 +12,65 @@ export async function getKatas() {
     })
   } catch (error) {
     console.error("Database Error:", error);
-    throw new Error("Failed to load stance data");
+    throw new Error("Failed to load kata data");
   }
+}
+
+export async function createKata(formData: FormData) {
+  try {
+    const validatedKataData = validateKataData(formData);
+
+    const existingKata = await prisma.kata.findUnique({
+      where: {
+        style_name: {
+          style: validatedKataData.style,
+          name: validatedKataData.name,
+        },
+      },
+    });
+    if (existingKata) {
+      throw new Error(`Kata "${validatedKataData.name}" already exists`);
+    }
+
+    const kata = await prisma.kata.create({
+      data: validatedKataData,
+    });
+
+    return kata;
+  } catch (error) {
+    console.error("Database error", error);
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error("Could not create new kata. Check inputs and try again.");
+  }
+}
+
+export async function createKataAction(
+  prevState: {
+    success: boolean;
+    error: string | null;
+    kata: Kata | null;
+    operation?: string;
+  } | null,
+  formData: FormData,
+) {
+  try {
+    const kata = await createKata(formData);
+    revalidatePath("/katas");
+    return {
+      success: true,
+      error: null,
+      kata,
+      operation: "create",
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message: "Failed to create kata",
+      kata: null,
+      operation: "create",
+    };
+  }
+
 }

--- a/lib/actions/katas.ts
+++ b/lib/actions/katas.ts
@@ -1,0 +1,17 @@
+"user server"
+
+import { revalidatePath } from "next/cache";
+import type { Kata } from "@/app/generated/prisma/browser";
+import prisma from "@/lib/prisma";
+import { validateKataData } from "@/lib/validation/katas";
+
+export async function getKatas() {
+  try {
+    return await prisma.kata.findMany({
+      orderBy: { id: "asc" },
+    })
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to load stance data");
+  }
+}

--- a/lib/actions/katas.ts
+++ b/lib/actions/katas.ts
@@ -155,3 +155,19 @@ export async function updateKataAction(
     };
   }
 }
+
+export async function deleteKata(id: number) {
+  try {
+    const deletedKata = await prisma.kata.delete({
+      where: { id },
+    });
+    revalidatePath("/katas");
+    return deletedKata;
+  } catch (error) {
+    console.error("Database error", error);
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error("Could not delete kata. Try again later.");
+  }
+}

--- a/lib/validation/katas.ts
+++ b/lib/validation/katas.ts
@@ -1,0 +1,55 @@
+import { getRequiredStringField, getOptionalStringField } from "./helpers";
+
+export interface ValidatedKataData {
+  style: string;
+  name: string;
+  series: string;
+  name_hiragana: string | null;
+  name_kanji: string | null;
+}
+
+export const KATA_FORM_FIELDS = {
+  STYLE: "kata_style",
+  NAME: "kata_name",
+  SERIES: "kata_series",
+  HIRAGANA: "kata_name_hiragana",
+  KANJI: "kata_name_kanji",
+} as const;
+
+export function validateKataData(formData: FormData): ValidatedKataData {
+  const style = getRequiredStringField(
+    formData,
+    KATA_FORM_FIELDS.STYLE,
+    "Karate style name is required"
+  );
+
+  const name = getRequiredStringField(
+    formData,
+    KATA_FORM_FIELDS.NAME,
+    "Kata name is required"
+  );
+
+  const series = getRequiredStringField(
+    formData,
+    KATA_FORM_FIELDS.SERIES,
+    "Kata series name is required"
+  );
+
+  const name_hiragana = getOptionalStringField(
+    formData,
+    KATA_FORM_FIELDS.HIRAGANA
+  );
+
+  const name_kanji = getOptionalStringField(
+    formData,
+    KATA_FORM_FIELDS.KANJI
+  );
+
+  return {
+    style,
+    name,
+    series,
+    name_hiragana,
+    name_kanji,
+  }
+}


### PR DESCRIPTION
- Add server actions for kata CRUD operations
- Add form validation helpers for kata data
- Include useActionState wrappers for create and update operations

- lib/validation/katas.ts
  - ValidatedKataData interface for typed kata data
  - KATA_FORM_FIELDS constants for form field names
  - validateKataData() function to validate form submissions

- lib/actions/katas.ts
  - getKatas() - fetch all katas ordered by ID
  - createKata() / createKataAction() - create kata with duplicate check using
  compound unique key (style + name)
  - updateKata() / updateKataAction() - update kata with existence check and
  duplicate validation
  - deleteKata() - delete kata by ID (cascades to related moves)