### PR TITLE
Kata list+form page

### DIFF
--- a/app/katas/columns.tsx
+++ b/app/katas/columns.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import type { Kata } from "@/app/generated/prisma/client";
+import { Button } from "@/components/ui/button";
+
+export const createColumns = (
+  onEdit: (kata: Kata) => void,
+  onDelete: (kata: Kata) => void,
+): ColumnDef<Kata>[] => [
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "series",
+    header: "Series",
+  },
+  {
+    accessorKey: "name_hiragana",
+    header: "Hiragana",
+  },
+  {
+    accessorKey: "name_kanji",
+    header: "Kanji",
+  },
+  {
+    id: "actions",
+    header: "Actions",
+    cell: ({ row }) => {
+      const kata = row.original;
+      return (
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => onEdit(kata)}>
+            Edit
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => onDelete(kata)}
+          >
+            Delete
+          </Button>
+        </div>
+      );
+    },
+  },
+];

--- a/app/katas/kata-form.tsx
+++ b/app/katas/kata-form.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useActionState, useEffect } from "react";
+import Form from "next/form";
+import { toast } from "sonner";
+import type { Kata } from "@/app/generated/prisma/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { createKataAction, updateKataAction } from "@/lib/actions/katas";
+import { KATA_FORM_FIELDS } from "@/lib/validation/katas";
+
+interface KataFormProps {
+  kata?: Kata | null;
+  onCancel?: () => void;
+}
+
+export function KataForm({ kata, onCancel }: KataFormProps) {
+  const isEditing = !!kata;
+
+  const [state, formAction, isPending] = useActionState(
+    isEditing ? updateKataAction : createKataAction,
+    null,
+  );
+
+  useEffect(() => {
+    if (state?.success) {
+      toast.success(
+        `Kata ${state.operation === "update" ? "updated" : "created"} successfully!`,
+      );
+
+      if (state.operation === "update" && onCancel) {
+        onCancel();
+      }
+    } else if (state?.error) {
+      toast.error(state.error);
+    }
+  }, [state?.success, state?.error, state?.operation, onCancel]);
+
+  return (
+    <Form key={kata?.id ?? "new"} action={formAction} className="space-y-4">
+      {/* Hidden ID field for updates */}
+      {isEditing && kata && (
+        <input type="hidden" name="id" value={kata.id} />
+      )}
+
+      {/* Style Name */}
+      <div className="space-y-2">
+        <Label htmlFor={KATA_FORM_FIELDS.STYLE}>Style Name</Label>
+        <Select
+          name={KATA_FORM_FIELDS.STYLE}
+          defaultValue={kata?.style || undefined}
+          required
+          disabled={isPending}
+        >
+          <SelectTrigger className="w-full max-w-48">
+            <SelectValue placeholder="Select a style" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectLabel>Styles</SelectLabel>
+              <SelectItem value="Shotokan">SHOTOKAN</SelectItem>
+              <SelectItem value="Shito-ryu">SHITO-RYU</SelectItem>
+              <SelectItem value="Goju-ryu">GOJU-RYU</SelectItem>
+              <SelectItem value="Wado-ryu">WADO-RYU</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Kata Name */}
+      <div className="space-y-2">
+        <Label htmlFor={KATA_FORM_FIELDS.NAME}>Kata Name</Label>
+        <Input
+          type="text"
+          id={KATA_FORM_FIELDS.NAME}
+          name={KATA_FORM_FIELDS.NAME}
+          placeholder="Add Kata Name"
+          defaultValue={kata?.name || undefined}
+          required
+          disabled={isPending}
+        />
+      </div>
+
+      {/* Series Name */}
+      <div className="space-y-2">
+        <Label htmlFor={KATA_FORM_FIELDS.SERIES}>Series Name</Label>
+        <Input
+          type="text"
+          id={KATA_FORM_FIELDS.SERIES}
+          name={KATA_FORM_FIELDS.SERIES}
+          placeholder="Add Series Name"
+          defaultValue={kata?.series || ""}
+          required
+          disabled={isPending}
+        />
+      </div>
+
+      {/* Hiragana */}
+      <div className="space-y-2">
+        <Label htmlFor={KATA_FORM_FIELDS.HIRAGANA}>Name (Hiragana)</Label>
+        <Input
+          type="text"
+          name={KATA_FORM_FIELDS.HIRAGANA}
+          id={KATA_FORM_FIELDS.HIRAGANA}
+          defaultValue={kata?.name_hiragana || ""}
+          disabled={isPending}
+        />
+      </div>
+
+      {/* Kanji */}
+      <div className="space-y-2">
+        <Label htmlFor={KATA_FORM_FIELDS.KANJI}>Name (Kanji)</Label>
+        <Input
+          type="text"
+          name={KATA_FORM_FIELDS.KANJI}
+          id={KATA_FORM_FIELDS.KANJI}
+          defaultValue={kata?.name_kanji || ""}
+          disabled={isPending}
+        />
+      </div>
+
+      {/* Submit and Cancel buttons */}
+      <div className="flex gap-2">
+        <Button type="submit" disabled={isPending}>
+          {isEditing ? "Update Kata" : "Add Kata"}
+        </Button>
+        {isEditing && onCancel && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+        )}
+      </div>
+    </Form>
+  );
+}
+

--- a/app/katas/kata-list.tsx
+++ b/app/katas/kata-list.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import type { Kata } from "@/app/generated/prisma/client";
+import { DataTable } from "@/components/data-table";
+import { createColumns } from "./columns";
+
+interface KataListProps {
+	katas: Kata[];
+}
+
+export function KataList({ katas }: KataListProps) {
+
+const columns = createColumns(() => {}, () => {});
+
+	return (
+		<div className="min-h-screen flex flex-col items-center justify-center -mt-16">
+			<h1 className="text-4xl font-bold mb-8">Katas</h1>
+				<div className="w-full max-w-4xl px-4">
+					<DataTable columns={columns} data={katas} />
+				</div>
+		</div>
+	);
+}

--- a/app/katas/kata-list.tsx
+++ b/app/katas/kata-list.tsx
@@ -3,6 +3,7 @@
 import type { Kata } from "@/app/generated/prisma/client";
 import { DataTable } from "@/components/data-table";
 import { createColumns } from "./columns";
+import { KataForm } from "./kata-form";
 
 interface KataListProps {
 	katas: Kata[];
@@ -15,6 +16,7 @@ const columns = createColumns(() => {}, () => {});
 	return (
 		<div className="min-h-screen flex flex-col items-center justify-center -mt-16">
 			<h1 className="text-4xl font-bold mb-8">Katas</h1>
+				<KataForm />
 				<div className="w-full max-w-4xl px-4">
 					<DataTable columns={columns} data={katas} />
 				</div>

--- a/app/katas/kata-list.tsx
+++ b/app/katas/kata-list.tsx
@@ -1,25 +1,125 @@
 "use client";
 
+import { useState, useRef, useEffect, useCallback } from "react";
+import { ChevronDown } from "lucide-react";
 import type { Kata } from "@/app/generated/prisma/client";
 import { DataTable } from "@/components/data-table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { deleteKata } from "@/lib/actions/katas";
 import { createColumns } from "./columns";
 import { KataForm } from "./kata-form";
 
 interface KataListProps {
-	katas: Kata[];
+  katas: Kata[];
 }
 
 export function KataList({ katas }: KataListProps) {
+  const [selectedKata, setSelectedKata] = useState<Kata | null>(null);
+  const [kataToDelete, setKataToDelete] = useState<Kata | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const collapsibleRef = useRef<HTMLDivElement>(null);
 
-const columns = createColumns(() => {}, () => {});
+  const handleEdit = (kata: Kata) => {
+    setSelectedKata(kata);
+    setIsOpen(true);
+  };
 
-	return (
-		<div className="min-h-screen flex flex-col items-center justify-center -mt-16">
-			<h1 className="text-4xl font-bold mb-8">Katas</h1>
-				<KataForm />
-				<div className="w-full max-w-4xl px-4">
-					<DataTable columns={columns} data={katas} />
-				</div>
-		</div>
-	);
+  const handleDelete = (kata: Kata) => {
+    setKataToDelete(kata);
+  };
+
+  const confirmDelete = async () => {
+    if (!kataToDelete) return;
+
+    try {
+      await deleteKata(kataToDelete.id);
+      setKataToDelete(null);
+    } catch (error) {
+      console.error("Failed to delete:", error);
+    }
+  };
+
+  const handleCancel = useCallback(() => {
+    setSelectedKata(null);
+    setIsOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => {
+        collapsibleRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }, 100);
+    }
+  }, [isOpen]);
+
+  const columns = createColumns(handleEdit, handleDelete);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
+      <h1 className="text-4xl font-bold mb-8">Katas</h1>
+      <div className="w-full max-w-4xl px-4">
+        <div ref={collapsibleRef}>
+          <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+            <CollapsibleTrigger asChild>
+              <div className="flex items-center justify-between gap-4 px-4">
+                <div className="text-sm font-semibold">
+                  {selectedKata ? "Edit Kata" : "Kata Creation Form"}
+                </div>
+                <Button variant="ghost" size="icon" className="size-8">
+                  <ChevronDown />
+                  <span className="sr-only">Toggle</span>
+                </Button>
+              </div>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="px-4">
+              <KataForm kata={selectedKata} onCancel={handleCancel} />
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      </div>
+      <div className="w-full max-w-4xl px-4">
+        <DataTable columns={columns} data={katas} />
+      </div>
+
+      <AlertDialog
+        open={!!kataToDelete}
+        onOpenChange={(open) => !open && setKataToDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the kata &quot;
+              {kataToDelete?.name}&quot;{" "}
+              <span className="font-semibold text-red-600 dark:text-red-400">
+                and all associated movesets
+              </span>
+              . This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDelete}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
 }

--- a/app/katas/page.tsx
+++ b/app/katas/page.tsx
@@ -1,0 +1,7 @@
+import { getKatas } from "@/lib/actions/katas";
+import { KataList } from "./kata-list";
+
+export default async function KataPageList() {
+  const katas = await getKatas();
+  return <KataList katas={katas} />
+}


### PR DESCRIPTION
# Add kata list page and wired to CRUD functionality (#7)

Implements kata management interface matching the existing stances and techniques page pattern.

## Summary
  - Add new /katas page with data table view
  - Add collapsible form interface for kata creation and editing
  - Include cascade deletion warning for associated movesets

  Kata List View
  - Data table displaying kata name, series, hiragana, and kanji
  - Edit and delete action buttons per row
  - Collapsible form section with toggle to minimize

  Kata Form
  - Dual-mode form supporting both create and edit operations
  - Required fields: style, name, series
  - Optional fields: hiragana and kanji names
  - Form validation and toast notifications for success/error states
  - Proper default values when editing existing data entries
  - Alert dialog before deletion