### PR TITLE
CSV bulk upload for Stances

### DIFF
--- a/app/stances/stances-list.tsx
+++ b/app/stances/stances-list.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { ChevronDown } from "lucide-react";
+import Link from "next/link";
 import type { Stance } from "@/app/generated/prisma/client";
 import { DataTable } from "@/components/data-table";
 import {
@@ -62,7 +63,10 @@ export function StancesList({ stances }: StancesListProps) {
   useEffect(() => {
     if (isOpen) {
       setTimeout(() => {
-        collapsibleRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+        collapsibleRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
       }, 100);
     }
   }, [isOpen]);
@@ -87,7 +91,18 @@ export function StancesList({ stances }: StancesListProps) {
               </div>
             </CollapsibleTrigger>
             <CollapsibleContent className="px-4">
-              <StanceForm stance={selectedStance} onCancel={handleCancel} />
+              <div className="space-y-4">
+                {!selectedStance && (
+                  <div className="flex justify-end">
+                    <Button asChild variant="link" size="sm">
+                      <Link href="/stances/upload">
+                        Batch upload multiple stances with CSV file
+                      </Link>
+                    </Button>
+                  </div>
+                )}
+                <StanceForm stance={selectedStance} onCancel={handleCancel} />
+              </div>
             </CollapsibleContent>
           </Collapsible>
         </div>

--- a/app/stances/upload/page.tsx
+++ b/app/stances/upload/page.tsx
@@ -1,0 +1,15 @@
+import { StanceUploadForm } from "./upload-form";
+
+export default function StanceUploadPage() {
+  return (
+    <div className="container mx-auto space-y-6 py-8">
+      <div>
+        <h1 className="text-3xl font-bold">Import Stances</h1>
+        <p className="text-muted-foreground">
+          Upload a CSV file to bulk import stances
+        </p>
+      </div>
+      <StanceUploadForm />
+    </div>
+  );
+}

--- a/app/stances/upload/upload-form.tsx
+++ b/app/stances/upload/upload-form.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function StanceUploadForm() {
+  const [file, setFile] = useState<File | null>(null);
+
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const selectedFile = event.target.files?.[0] || null;
+    if (selectedFile) {
+      setFile(selectedFile);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2>Upload Stance CSV file</h2>
+      <Input type="file" accept=".csv" onChange={handleFileChange} />
+      <Button disabled={!file}>
+        Parse CSV file
+      </Button>
+    </div>
+  );
+}

--- a/app/stances/upload/upload-form.tsx
+++ b/app/stances/upload/upload-form.tsx
@@ -1,11 +1,20 @@
 "use client";
 
 import { useState } from "react";
+import Papa from "papaparse";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
+interface StanceCsvRow {
+  name: string;
+  hiragana: string;
+  kanji: string;
+}
+
 export function StanceUploadForm() {
   const [file, setFile] = useState<File | null>(null);
+  const [parsedData, setParsedData] = useState<StanceCsvRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     const selectedFile = event.target.files?.[0] || null;
@@ -14,13 +23,43 @@ export function StanceUploadForm() {
     }
   }
 
+  function handleParseFile() {
+    if (!file) return;
+
+    Papa.parse<StanceCsvRow>(file, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (header) => header.trim().toLowerCase(),
+      transform: (value) => value.trim(),
+      complete: (results) => {
+        console.log("Parsed CSV data:", results.data);
+        setParsedData(results.data);
+        setError(null);
+      },
+      error: (error) => {
+        setError(`Failed to parse: ${error.message}`);
+      },
+    });
+  }
+
   return (
     <div className="space-y-4">
       <h2>Upload Stance CSV file</h2>
       <Input type="file" accept=".csv" onChange={handleFileChange} />
-      <Button disabled={!file}>
+      <Button onClick={handleParseFile} disabled={!file}>
         Parse CSV file
       </Button>
+
+      {error && <div className="text-sm text-destructive">{error}</div>}
+
+      {parsedData && parsedData.length > 0 && (
+        <div className="mt-4">
+          <p>Parsed {parsedData.length} rows!</p>
+          <pre className="text-xs bg-muted p-2 rounded overflow-auto">
+            {JSON.stringify(parsedData, null, 2)}
+          </pre>
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/actions/csv-upload.ts
+++ b/lib/actions/csv-upload.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import prisma from "@/lib/prisma";
+import type { ValidatedStanceData } from "@/lib/validation/stances";
+
+interface ImportResult {
+  success: boolean;
+  error: string | null;
+  createdCount: number;
+  skippedCount: number;
+}
+
+export async function importStancesAction(
+  validStances: ValidatedStanceData[],
+): Promise<ImportResult> {
+  try {
+    const names = validStances.map((s) => s.name);
+    const existingStances = await prisma.stance.findMany({
+      where: { name: { in: names } },
+      select: { name: true },
+    });
+
+    if (existingStances.length > 0) {
+      const duplicateNames = existingStances.map((s) => s.name).join(", ");
+      return {
+        success: false,
+        error: `Stances with the following names already exist: ${duplicateNames}`,
+        createdCount: 0,
+        skippedCount: existingStances.length,
+      };
+    }
+
+    const createdStances = await prisma.$transaction(
+      validStances.map((stance) =>
+        prisma.stance.create({
+          data: {
+            name: stance.name,
+            name_hiragana: stance.name_hiragana,
+            name_kanji: stance.name_kanji,
+          },
+        }),
+      ),
+    );
+
+    revalidatePath("/stances");
+
+    return {
+      success: true,
+      error: null,
+      createdCount: createdStances.length,
+      skippedCount: 0,
+    };
+  } catch (error) {
+    console.error("Error importing stances:", error);
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to import stances",
+      createdCount: 0,
+      skippedCount: 0,
+    };
+  }
+}

--- a/lib/validation/csv-stances.ts
+++ b/lib/validation/csv-stances.ts
@@ -1,0 +1,34 @@
+import type { ValidatedStanceData } from "./stances";
+
+export interface StanceCsvRow {
+  name: string;
+  hiragana: string;
+  kanji: string;
+}
+
+export interface ValidatedRow {
+  data: ValidatedStanceData;
+  rowNumber: number;
+  isValid: boolean;
+  errors: string[];
+}
+
+export function validateStanceCSVRow(
+  row: StanceCsvRow,
+  rowNumber: number,
+): ValidatedRow {
+  const errors: string[] = [];
+  const name = row.name?.trim() || "";
+  if (!name) {
+    errors.push("Name is required");
+  }
+  const name_hiragana = row.hiragana.trim() || null;
+  const name_kanji = row.kanji.trim() || null;
+
+  return {
+    data: { name, name_hiragana, name_kanji },
+    rowNumber,
+    isValid: errors.length === 0,
+    errors,
+  };
+}

--- a/lib/validation/csv-stances.ts
+++ b/lib/validation/csv-stances.ts
@@ -1,7 +1,7 @@
 import type { ValidatedStanceData } from "./stances";
 
 export interface StanceCsvRow {
-  name: string;
+  "stance name": string;
   hiragana: string;
   kanji: string;
 }
@@ -18,12 +18,12 @@ export function validateStanceCSVRow(
   rowNumber: number,
 ): ValidatedRow {
   const errors: string[] = [];
-  const name = row.name?.trim() || "";
+  const name = row["stance name"]?.trim() || "";
   if (!name) {
     errors.push("Name is required");
   }
-  const name_hiragana = row.hiragana.trim() || null;
-  const name_kanji = row.kanji.trim() || null;
+  const name_hiragana = row.hiragana?.trim() || null;
+  const name_kanji = row.kanji?.trim() || null;
 
   return {
     data: { name, name_hiragana, name_kanji },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "dotenv": "^17.2.3",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
+        "papaparse": "^5.5.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "sonner": "^2.0.7",
@@ -32,6 +33,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20.19.27",
+        "@types/papaparse": "^5.5.2",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -3235,6 +3237,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -7456,6 +7468,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dotenv": "^17.2.3",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
+    "papaparse": "^5.5.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "sonner": "^2.0.7",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20.19.27",
+    "@types/papaparse": "^5.5.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",


### PR DESCRIPTION
Bulk import functionality that allows users to upload multiple stances by CSV file.
Simple display of CSV data after upload.

- CSV Upload Page (`/stances/upload`)
  - File input field that accepts .csv files
  - CSV parsing with papaparse
  - Validation of CSV headers and data
    - Prevents import of data if expected headers aren't there. Strict rules.
  - Displays valid/invalid row counts
- Validation in `lib/validation/csv-upload.ts`
- Import Functionality in `lib/action/csv-stances.ts`
  - Prevents import of data if there are any existing stance data
  - All or nothing server action with Prisma transaction
- Navigation Button
  - Link to upload page from collapsible stance creation form