### PR TITLE
Add kata-moves page with filterable table

### DIFF
--- a/app/kata-moves/columns.tsx
+++ b/app/kata-moves/columns.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import type { Prisma } from '@/app/generated/prisma/client';
+
+export type MoveWithRelations = Prisma.MoveGetPayload<{
+  include: {
+    kata: true;
+    stance: true;
+    technique: true;
+  };
+}>;
+
+export const columns: ColumnDef<MoveWithRelations>[] = [
+  {
+    accessorKey: "kata.name",
+    header: "Kata",
+  },
+  {
+    accessorKey: "move_number",
+    header: "Move #",
+  },
+  {
+    accessorKey: "sequence",
+    header: "Seq",
+  },
+  {
+    accessorKey: "direction",
+    header: "Direction",
+  },
+  {
+    accessorKey: "stance.name",
+    header: "Stance",
+  },
+  {
+    accessorKey: "lead_foot",
+    header: "Lead Foot",
+  },
+  {
+    accessorKey: "hip",
+    header: "Hip Position",
+  },
+  {
+    accessorKey: "technique.type",
+    header: "Tech Type",
+  },
+  {
+    accessorKey: "technique.name",
+    header: "Technique",
+  },
+  {
+    accessorKey: "active_side",
+    header: "Active Side",
+  },
+  {
+    accessorKey: "speed",
+    header: "Speed",
+  },
+  {
+    accessorKey: "snap_thrust",
+    header: "Snap/Thrust",
+  },
+  {
+    accessorKey: "level",
+    header: "Level",
+  },
+  {
+    accessorKey: "breath",
+    header: "Breath",
+  },
+  {
+    accessorKey: "kiai",
+    header: "Kiai",
+    cell: ({ row }) => (row.original.kiai ? "Yes" : "No"),
+  },
+];

--- a/app/kata-moves/columns.tsx
+++ b/app/kata-moves/columns.tsx
@@ -21,8 +21,8 @@ export const columns: ColumnDef<MoveWithRelations>[] = [
     header: "Move #",
   },
   {
-    accessorKey: "sequence",
-    header: "Seq",
+    accessorKey: "timing",
+    header: "Timing",
   },
   {
     accessorKey: "direction",

--- a/app/kata-moves/kata-moves-data-table.tsx
+++ b/app/kata-moves/kata-moves-data-table.tsx
@@ -96,7 +96,7 @@ const snapThrustOptions: FilterOption[] = [
   { value: "SNAP", label: "Snap" },
   { value: "THRUST", label: "Thrust" },
 ]
-const breadthOptions: FilterOption[] = [
+const breathOptions: FilterOption[] = [
   { value: "IN", label: "Inhale" },
   { value: "OUT", label: "Exhale" },
   { value: "IN_OUT", label: "In → Out" },
@@ -236,7 +236,7 @@ export function KataMovesDataTable({
               <ColumnFilter table={table} columnId="active_side" label="Active Side" options={activeSideOptions}/>
               <ColumnFilter table={table} columnId="speed" label="Speed" options={speedOptions}/>
               <ColumnFilter table={table} columnId="snap_thrust" label="Snap/Thrust" options={snapThrustOptions}/>
-              <ColumnFilter table={table} columnId="breadth" label="Breath" options={breadthOptions}/>
+              <ColumnFilter table={table} columnId="breath" label="Breath" options={breathOptions}/>
               <KiaiFilter table={table} />
             </div>
           </CollapsibleContent>

--- a/app/kata-moves/kata-moves-data-table.tsx
+++ b/app/kata-moves/kata-moves-data-table.tsx
@@ -42,6 +42,57 @@ interface KataMovesDataTableProps {
   data: MoveWithRelations[]
 }
 
+type FilterOption = { value: string; label: string }
+
+const techniqueTypeOptions: FilterOption[] = [
+  { value: "BLOCK", label: "Block" },
+  { value: "PUNCH", label: "Punch" },
+  { value: "KICK", label: "Kick" },
+  { value: "STRIKE", label: "Strike" },
+  { value: "PREP", label: "Prep" },
+]
+const directionOptions: FilterOption[] = [
+  { value: "N", label: "North" },
+  { value: "S", label: "South" },
+  { value: "E", label: "East" },
+  { value: "W", label: "West" },
+  { value: "NE", label: "Northeast" },
+  { value: "NW", label: "Northwest" },
+  { value: "SE", label: "Southeast" },
+  { value: "SW", label: "Southwest" },
+]
+const techniqueLevelOptions: FilterOption[] = [
+  { value: "GEDAN", label: "Gedan (Lower)" },
+  { value: "CHUDAN", label: "Chudan (Middle)" },
+  { value: "JODAN", label: "Jodan (Upper)" },
+  { value: "GEDAN_JODAN", label: "Gedan & Jodan" },
+]
+const leadFootOptions: FilterOption[] = [
+  { value: "LEFT", label: "Left" },
+  { value: "RIGHT", label: "Right" },
+]
+const hipOptions: FilterOption[] = [
+  { value: "HANMI", label: "Hanmi" },
+  { value: "SHOMEN", label: "Shomen" },
+  { value: "GYAKUHANMI", label: "Gyaku Hanmi" },
+]
+const activeSideOptions: FilterOption[] = [
+  { value: "LEFT", label: "Left" },
+  { value: "RIGHT", label: "Right" },
+  { value: "BOTH", label: "Both" },
+  { value: "NEITHER", label: "Neither" },
+]
+const speedOptions: FilterOption[] = [
+  { value: "FAST", label: "Fast" },
+  { value: "SLOW", label: "Slow" },
+  { value: "FAST_SLOW", label: "Fast → Slow" },
+  { value: "SLOW_FAST", label: "Slow → Fast" },
+]
+const snapThrustOptions: FilterOption[] = [
+  { value: "SNAP", label: "Snap" },
+  { value: "THRUST", label: "Thrust" },
+]
+
 function ColumnFilter({
   table,
   columnId,
@@ -51,15 +102,16 @@ function ColumnFilter({
   table: TanStackTable<MoveWithRelations>
   columnId: string
   label: string
-  options?: string[]
+  options?: FilterOption[]
 }) {
   const column = table.getColumn(columnId)
-  const uniqueValues = options ?? Array.from(
+
+  const selectOptions: FilterOption[] = options ?? Array.from(
     column?.getFacetedUniqueValues()?.keys() ?? []
   )
     .filter((v) => v != null && v !== "")
     .sort()
-    .map(String)
+    .map((v) => ({ value: String(v), label: String(v) }))
 
   const filterValue = column?.getFilterValue() as string | undefined
 
@@ -77,9 +129,9 @@ function ColumnFilter({
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="all">All</SelectItem>
-          {uniqueValues.map((value) => (
-            <SelectItem key={value} value={value}>
-              {value}
+          {selectOptions.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
             </SelectItem>
           ))}
         </SelectContent>
@@ -148,7 +200,7 @@ export function KataMovesDataTable({
         <div className="flex flex-wrap gap-4 items-end">
           <ColumnFilter table={table} columnId="kata_name" label="Kata" />
           <ColumnFilter table={table} columnId="stance_name" label="Stance" />
-          <ColumnFilter table={table} columnId="technique_type" label="Tech Type" options={Object.values(TechniqueType)}/>
+          <ColumnFilter table={table} columnId="technique_type" label="Tech Type" options={techniqueTypeOptions}/>
           <ColumnFilter table={table} columnId="technique_name" label="Technique" />
           {columnFilters.length > 0 && (
             <Button variant="ghost" onClick={() => setColumnFilters([])} className="self-end">
@@ -167,13 +219,13 @@ export function KataMovesDataTable({
           </CollapsibleTrigger>
           <CollapsibleContent className="pt-4">
             <div className="flex flex-wrap gap-4">
-              <ColumnFilter table={table} columnId="direction" label="Direction" options={Object.values()}/>
-              <ColumnFilter table={table} columnId="level" label="Level" options={Object.values()}/>
-              <ColumnFilter table={table} columnId="lead_foot" label="Lead Foot" options={Object.values()}/>
-              <ColumnFilter table={table} columnId="hip" label="Hip Position" options={Object.values()}/>
-              <ColumnFilter table={table} columnId="active_side" label="Active Side" options={Object.values()}/>
-              <ColumnFilter table={table} columnId="speed" label="Speed" options={Object.values()}/>
-              <ColumnFilter table={table} columnId="snap_thrust" label="Snap/Thrust" options={Object.values()}/>
+              <ColumnFilter table={table} columnId="direction" label="Direction" options={directionOptions}/>
+              <ColumnFilter table={table} columnId="level" label="Level" options={techniqueLevelOptions}/>
+              <ColumnFilter table={table} columnId="lead_foot" label="Lead Foot" options={leadFootOptions}/>
+              <ColumnFilter table={table} columnId="hip" label="Hip Position" options={hipOptions}/>
+              <ColumnFilter table={table} columnId="active_side" label="Active Side" options={activeSideOptions}/>
+              <ColumnFilter table={table} columnId="speed" label="Speed" options={speedOptions}/>
+              <ColumnFilter table={table} columnId="snap_thrust" label="Snap/Thrust" options={snapThrustOptions}/>
               <ColumnFilter table={table} columnId="breath" label="Breath"/> {/* TODO ADD BREADTH TO DB */}
               <KiaiFilter table={table} />
             </div>

--- a/app/kata-moves/kata-moves-data-table.tsx
+++ b/app/kata-moves/kata-moves-data-table.tsx
@@ -1,0 +1,229 @@
+"use client"
+
+import * as React from "react"
+import { ChevronDownIcon } from "lucide-react"
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  Table as TanStackTable,
+  useReactTable,
+} from "@tanstack/react-table"
+import { Button } from "@/components/ui/button"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+import type { MoveWithRelations } from "./columns";
+
+interface KataMovesDataTableProps {
+  columns: ColumnDef<MoveWithRelations, unknown>[]
+  data: MoveWithRelations[]
+}
+
+function ColumnFilter({
+  table,
+  columnId,
+  label,
+  options,
+}: {
+  table: TanStackTable<MoveWithRelations>
+  columnId: string
+  label: string
+  options?: string[]
+}) {
+  const column = table.getColumn(columnId)
+  const uniqueValues = options ?? Array.from(
+    column?.getFacetedUniqueValues()?.keys() ?? []
+  )
+    .filter((v) => v != null && v !== "")
+    .sort()
+    .map(String)
+
+  const filterValue = column?.getFilterValue() as string | undefined
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs text-muted-foreground">{label}</label>
+      <Select
+        value={filterValue ?? "all"}
+        onValueChange={(value) =>
+          column?.setFilterValue(value === "all" ? undefined : value)
+        }
+      >
+        <SelectTrigger className="min-w-[140px]">
+          <SelectValue placeholder={`All ${label}`} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All</SelectItem>
+          {uniqueValues.map((value) => (
+            <SelectItem key={value} value={value}>
+              {value}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function KiaiFilter({
+  table,
+}: {
+  table: TanStackTable<MoveWithRelations>
+}) {
+  const column = table.getColumn("kiai")
+  const filterValue = column?.getFilterValue()
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs text-muted-foreground">Kiai</label>
+      <Select
+        value={filterValue === undefined ? "all" : filterValue ? "yes" : "no"}
+        onValueChange={(value) => {
+          if (value === "all") column?.setFilterValue(undefined)
+          else column?.setFilterValue(value === "yes")
+        }}
+      >
+        <SelectTrigger className="min-w-[140px]">
+          <SelectValue placeholder="All" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All</SelectItem>
+          <SelectItem value="yes">Yes</SelectItem>
+          <SelectItem value="no">No</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+export function KataMovesDataTable({
+  columns,
+  data,
+}: KataMovesDataTableProps) {
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    []
+  )
+  const [moreFiltersOpen, setMoreFiltersOpen] = React.useState(false)
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    onColumnFiltersChange: setColumnFilters,
+    getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+    state: {
+      columnFilters,
+    },
+  })
+
+  return (
+    <div>
+      <div className="space-y-4 py-4">
+        {/* Major filters */}
+        <div className="flex flex-wrap gap-4 items-end">
+          <ColumnFilter table={table} columnId="kata_name" label="Kata" />
+          <ColumnFilter table={table} columnId="stance_name" label="Stance" />
+          <ColumnFilter table={table} columnId="technique_type" label="Tech Type" options={Object.values(TechniqueType)}/>
+          <ColumnFilter table={table} columnId="technique_name" label="Technique" />
+          {columnFilters.length > 0 && (
+            <Button variant="ghost" onClick={() => setColumnFilters([])} className="self-end">
+              Reset filters
+            </Button>
+          )}
+        </div>
+
+        {/* Minor filters */}
+        <Collapsible open={moreFiltersOpen} onOpenChange={setMoreFiltersOpen}>
+          <CollapsibleTrigger asChild>
+            <Button variant="outline" size="sm" className="flex items-center gap-1">
+              More filters
+              <ChevronDownIcon className={`size-4 transition-transform ${moreFiltersOpen ? "rotate-180" : ""}`} />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="pt-4">
+            <div className="flex flex-wrap gap-4">
+              <ColumnFilter table={table} columnId="direction" label="Direction" options={Object.values()}/>
+              <ColumnFilter table={table} columnId="level" label="Level" options={Object.values()}/>
+              <ColumnFilter table={table} columnId="lead_foot" label="Lead Foot" options={Object.values()}/>
+              <ColumnFilter table={table} columnId="hip" label="Hip Position" options={Object.values()}/>
+              <ColumnFilter table={table} columnId="active_side" label="Active Side" options={Object.values()}/>
+              <ColumnFilter table={table} columnId="speed" label="Speed" options={Object.values()}/>
+              <ColumnFilter table={table} columnId="snap_thrust" label="Snap/Thrust" options={Object.values()}/>
+              <ColumnFilter table={table} columnId="breath" label="Breath"/> {/* TODO ADD BREADTH TO DB */}
+              <KiaiFilter table={table} />
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+      <div className="overflow-hidden rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </TableHead>
+                  )
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/app/kata-moves/kata-moves-data-table.tsx
+++ b/app/kata-moves/kata-moves-data-table.tsx
@@ -51,6 +51,10 @@ const techniqueTypeOptions: FilterOption[] = [
   { value: "STRIKE", label: "Strike" },
   { value: "PREP", label: "Prep" },
 ]
+const timingOptions: FilterOption[] = [
+  { value: "SIMULTANEOUS", label: "Simultaneous" },
+  { value: "SEQUENTIAL", label: "Sequential" },
+]
 const directionOptions: FilterOption[] = [
   { value: "N", label: "North" },
   { value: "S", label: "South" },
@@ -219,6 +223,7 @@ export function KataMovesDataTable({
           </CollapsibleTrigger>
           <CollapsibleContent className="pt-4">
             <div className="flex flex-wrap gap-4">
+              <ColumnFilter table={table} columnId="timing" label="Timing" options={timingOptions}/>
               <ColumnFilter table={table} columnId="direction" label="Direction" options={directionOptions}/>
               <ColumnFilter table={table} columnId="level" label="Level" options={techniqueLevelOptions}/>
               <ColumnFilter table={table} columnId="lead_foot" label="Lead Foot" options={leadFootOptions}/>

--- a/app/kata-moves/kata-moves-data-table.tsx
+++ b/app/kata-moves/kata-moves-data-table.tsx
@@ -96,6 +96,11 @@ const snapThrustOptions: FilterOption[] = [
   { value: "SNAP", label: "Snap" },
   { value: "THRUST", label: "Thrust" },
 ]
+const breadthOptions: FilterOption[] = [
+  { value: "IN", label: "Inhale" },
+  { value: "OUT", label: "Exhale" },
+  { value: "IN_OUT", label: "In → Out" },
+]
 
 function ColumnFilter({
   table,
@@ -231,7 +236,7 @@ export function KataMovesDataTable({
               <ColumnFilter table={table} columnId="active_side" label="Active Side" options={activeSideOptions}/>
               <ColumnFilter table={table} columnId="speed" label="Speed" options={speedOptions}/>
               <ColumnFilter table={table} columnId="snap_thrust" label="Snap/Thrust" options={snapThrustOptions}/>
-              <ColumnFilter table={table} columnId="breath" label="Breath"/> {/* TODO ADD BREADTH TO DB */}
+              <ColumnFilter table={table} columnId="breadth" label="Breath" options={breadthOptions}/>
               <KiaiFilter table={table} />
             </div>
           </CollapsibleContent>

--- a/app/kata-moves/kata-moves-list.tsx
+++ b/app/kata-moves/kata-moves-list.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { DataTable } from "@/components/data-table";
 import { columns } from "./columns";
 import type { MoveWithRelations } from "./columns";
+import { KataMovesDataTable } from "./kata-moves-data-table";
 
 interface KataMovesListProps {
   movesets: MoveWithRelations[];
@@ -18,7 +18,7 @@ export function KataMovesList({ movesets }: KataMovesListProps) {
         </p>
       </div>
 
-      <DataTable
+      <KataMovesDataTable
         columns={columns}
         data={movesets}
       />

--- a/app/kata-moves/kata-moves-list.tsx
+++ b/app/kata-moves/kata-moves-list.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { DataTable } from "@/components/data-table";
+import { columns } from "./columns";
+import type { MoveWithRelations } from "./columns";
+
+interface KataMovesListProps {
+  movesets: MoveWithRelations[];
+}
+
+export function KataMovesList({ movesets }: KataMovesListProps) {
+  return (
+    <div>
+      <div>
+        <h1 className="text-2xl font-bold">Kata Moves</h1>
+        <p className="text-muted-foreground">
+          View all moves across all katas
+        </p>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={movesets}
+      />
+    </div>
+  )
+}

--- a/app/kata-moves/page.tsx
+++ b/app/kata-moves/page.tsx
@@ -1,0 +1,8 @@
+import { getMovesets } from "@/lib/actions/movesets";
+import { KataMovesList } from "./kata-moves-list";
+
+export default async function KataMovesPage() {
+	const movesets = await getMovesets();
+
+	return <KataMovesList movesets={movesets} />;
+}

--- a/app/kata-moves/page.tsx
+++ b/app/kata-moves/page.tsx
@@ -1,8 +1,8 @@
-import { getMovesets } from "@/lib/actions/movesets";
+import { getKataMoves } from "@/lib/actions/kata-moves";
 import { KataMovesList } from "./kata-moves-list";
 
 export default async function KataMovesPage() {
-	const movesets = await getMovesets();
+	const movesets = await getKataMoves();
 
 	return <KataMovesList movesets={movesets} />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,10 @@ export default function Home() {
       title: "Techniques",
       href: "/techniques",
     },
+    {
+      title: "Kata Moves",
+      href: "/kata-moves",
+    },
   ];
 
   return (
@@ -34,6 +38,16 @@ export default function Home() {
               <p>一、努力の精神を養うこと</p>
               <p>一、礼儀を重んずること</p>
               <p>一、血気の勇を戒むること</p>
+            </div>
+          </div>
+          <div className="space-y-3">
+            <h2 className="text-xl font-semibold border-b pb-2">Dojo kun</h2>
+            <div className="space-y-1 text-muted-foreground">
+              <p>Hitotsu, jinkaku kansei ni tsutomuru koto</p>
+              <p>Hitotsu, makoto no michi wo mamoru koto</p>
+              <p>Hitotsu, doryoku no seishin wo yashinau koto</p>
+              <p>Hitotsu, reigi wo omonzuru koto</p>
+              <p>Hitotsu, kekki no yū wo imashimuru koto</p>
             </div>
           </div>
           <div className="space-y-3">

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -30,6 +30,10 @@ const navigationLinks = [
     title: "Techniques",
     url: "/techniques",
   },
+  {
+    title: "Kata Moves",
+    url: "/kata-moves",
+  },
 ];
 
 export function AppSidebar() {

--- a/lib/actions/kata-moves.ts
+++ b/lib/actions/kata-moves.ts
@@ -2,7 +2,7 @@
 
 import prisma from "@/lib/prisma";
 
-export async function getMovesets() {
+export async function getKataMoves() {
   try {
     return await prisma.move.findMany({
       include: {

--- a/lib/actions/movesets.ts
+++ b/lib/actions/movesets.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+
+export async function getMovesets() {
+  try {
+    return await prisma.move.findMany({
+      include: {
+        kata: true,
+        stance: true,
+        technique: true,
+      },
+      orderBy: [
+        { kata_id: "asc" },
+        { move_number: "asc" },
+        { sequence: "asc" },
+      ],
+    });
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to load moveset data");
+  }
+}

--- a/prisma/migrations/20260212231918_make_timing_optional_sequence_defaults_1/migration.sql
+++ b/prisma/migrations/20260212231918_make_timing_optional_sequence_defaults_1/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Move" ALTER COLUMN "sequence" SET DEFAULT 1,
+ALTER COLUMN "timing" DROP NOT NULL;

--- a/prisma/migrations/20260213002359_add_breath_enum_to_move_model/migration.sql
+++ b/prisma/migrations/20260213002359_add_breath_enum_to_move_model/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Added the required column `breath` to the `Move` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "Breath" AS ENUM ('IN', 'OUT', 'IN_OUT');
+
+-- AlterTable
+ALTER TABLE "Move" ADD COLUMN     "breath" "Breath" NOT NULL;
+
+-- DropEnum
+DROP TYPE "Breadth";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Move {
   snap_thrust SnapThrust
   level TechniqueLevel
   interm_move Boolean
+  breath Breath
   kiai Boolean
 
   @@unique([kata_id, move_number, sequence])
@@ -128,7 +129,7 @@ enum TechniqueLevel {
   GEDAN_JODAN // Both lower and upper level
 }
 
-enum Breadth {
+enum Breath {
   IN 
   OUT 
   IN_OUT

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,8 +30,8 @@ model Move {
   kata_id Int
   kata Kata @relation(fields: [kata_id], references: [id], onDelete: Cascade)
   move_number Int
-  sequence Int
-  timing MoveTiming
+  sequence Int @default(1)
+  timing MoveTiming?
   stance_id Int
   stance Stance @relation(fields: [stance_id], references: [id])
   technique_id Int


### PR DESCRIPTION
- Adds a `/kata-moves` page that displays all moves across all katas in a data table
- Implements a kata-moves specific data table with major filters (kata, stance, technique type, technique) always visible and minor filters (direction, level, timing, lead foot, hip, active side, speed, snap/thrust, breath, kiai) in a collapsible section
- Filter dropdowns for enum fields use human-readable labels mapped to DB enum values, avoiding Prisma client imports in client components
- Updates the Move model: sequence gets a default of 1, timing becomes optional, and breadth is added
- Adds navigation links to the kata-moves page from the homepage and sidebar
