### PR TITLE
Add kata-oves upload page with manual entry and CSV import 

### DIFF
--- a/app/kata-moves/upload/csv-upload-form.tsx
+++ b/app/kata-moves/upload/csv-upload-form.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useRef, useState } from "react";
+import Papa from "papaparse";
+import type { Stance, Technique } from "@/app/generated/prisma/browser";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type {
+  MoveFormState,
+  ValidatedMoveData,
+} from "@/lib/validation/kata-moves";
+import {
+  validateMoveCsvRow,
+  type MoveRow,
+  type ValidatedMoveRow,
+} from "@/lib/validation/csv-kata-moves";
+
+const EXPECTED_HEADERS = [
+  "move_number",
+  "sequence",
+  "timing",
+  "stance",
+  "technique",
+  "direction",
+  "lead_foot",
+  "hip",
+  "active_side",
+  "speed",
+  "snap_thrust",
+  "level",
+  "breath",
+  "interm_move",
+  "kiai",
+];
+
+function toFormState(move: ValidatedMoveData): Partial<MoveFormState> {
+  return {
+    move_number: move.move_number,
+    sequence: move.sequence,
+    timing: move.timing ?? "NONE",
+    stance_id: String(move.stance_id),
+    technique_id: String(move.technique_id),
+    direction: move.direction,
+    lead_foot: move.lead_foot,
+    hip: move.hip,
+    active_side: move.active_side,
+    speed: move.speed,
+    snap_thrust: move.snap_thrust,
+    level: move.level,
+    breath: move.breath,
+    interm_move: move.interm_move ? "true" : "false",
+    kiai: move.kiai ? "true" : "false",
+  };
+}
+
+interface Props {
+  stances: Stance[];
+  techniques: Technique[];
+  onReview: (values: Partial<MoveFormState>) => void;
+  onAddAll: (moves: ValidatedMoveData[]) => void;
+}
+
+export function CsvUploadForm({
+  stances,
+  techniques,
+  onReview,
+  onAddAll,
+}: Props) {
+  const [parsedRows, setParsedRows] = useState<ValidatedMoveRow[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  function handleParse() {
+    const file = fileInputRef.current?.files?.[0];
+    if (!file) return;
+
+    Papa.parse<MoveRow>(file, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (h) => h.trim().toLowerCase(),
+      transform: (v) => v.trim(),
+      complete: (results) => {
+        const headers = results.meta.fields ?? [];
+        const missingHeaders = EXPECTED_HEADERS.filter(
+          (h) => !headers.includes(h),
+        );
+        if (missingHeaders.length > 0) {
+          setParseError(`Missing columns: ${missingHeaders.join(", ")}`);
+          setParsedRows([]);
+          return;
+        }
+        setParseError(null);
+        const rows = results.data.map((row, i) =>
+          validateMoveCsvRow(row, i + 1, stances, techniques),
+        );
+        setParsedRows(rows);
+      },
+    });
+  }
+
+  const validRows = parsedRows.filter((r) => r.isValid && r.data);
+  const invalidCount = parsedRows.filter((r) => !r.isValid).length;
+
+  return (
+    <div className="space-y-4 py-4">
+      <div className="flex items-center gap-2">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".csv"
+          className="text-sm"
+        />
+        <Button variant="outline" onClick={handleParse}>
+          Parse
+        </Button>
+      </div>
+
+      {parseError && <p className="text-sm text-destructive">{parseError}</p>}
+
+      {parsedRows.length > 0 && (
+        <>
+          <p className="text-sm text-muted-foreground">
+            {validRows.length} valid, {invalidCount} invalid
+          </p>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Row</TableHead>
+                  <TableHead>Move #</TableHead>
+                  <TableHead>Stance</TableHead>
+                  <TableHead>Technique</TableHead>
+                  <TableHead>Direction</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {parsedRows.map((row) => (
+                  <TableRow key={row.rowNumber}>
+                    <TableCell>{row.rowNumber}</TableCell>
+                    <TableCell>{row.data?.move_number ?? "—"}</TableCell>
+                    <TableCell>
+                      {row.data
+                        ? stances.find((s) => s.id === row.data!.stance_id)
+                            ?.name
+                        : "—"}
+                    </TableCell>
+                    <TableCell>
+                      {row.data
+                        ? techniques.find(
+                            (t) => t.id === row.data!.technique_id,
+                          )?.name
+                        : "—"}
+                    </TableCell>
+                    <TableCell>{row.data?.direction ?? "—"}</TableCell>
+                    <TableCell>
+                      {row.isValid ? (
+                        <span className="text-green-600 text-sm">✓</span>
+                      ) : (
+                        <span
+                          className="text-destructive text-sm"
+                          title={row.errors.join(", ")}
+                        >
+                          ✗ {row.errors[0]}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {row.isValid && row.data && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => onReview(toFormState(row.data!))}
+                        >
+                          Review
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+          {validRows.length > 0 && (
+            <Button onClick={() => onAddAll(validRows.map((r) => r.data!))}>
+              Add all valid rows to Queue ({validRows.length})
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/kata-moves/upload/manual-move-form.tsx
+++ b/app/kata-moves/upload/manual-move-form.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Stance, Technique } from "@/app/generated/prisma/browser";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  validateMoveForm,
+  type MoveFormState,
+  type ValidatedMoveData,
+} from "@/lib/validation/kata-moves";
+
+const EMPTY_FORM: MoveFormState = {
+  move_number: "",
+  sequence: 1,
+  timing: "",
+  stance_id: "",
+  technique_id: "",
+  direction: "",
+  lead_foot: "",
+  hip: "",
+  active_side: "",
+  speed: "",
+  snap_thrust: "",
+  level: "",
+  breath: "",
+  interm_move: "",
+  kiai: "",
+};
+
+interface Props {
+  stances: Stance[];
+  techniques: Technique[];
+  initialValues?: Partial<MoveFormState>;
+  onAdd: (move: ValidatedMoveData) => boolean;
+}
+
+export function MoveForm({ stances, techniques, initialValues, onAdd }: Props) {
+  const [form, setForm] = useState<MoveFormState>({
+    ...EMPTY_FORM,
+    ...initialValues,
+  });
+  const [errors, setErrors] = useState<string[]>([]);
+
+  // Re-populate form when initialValues changes (e.g. CSV row review)
+  useEffect(() => {
+    setForm({ ...EMPTY_FORM, ...initialValues });
+  }, [initialValues]);
+
+  function handleAdd() {
+    const { data, errors } = validateMoveForm(form);
+    if (!data) {
+      setErrors(errors);
+      return;
+    }
+    const added = onAdd(data);
+    if (added) {
+      setForm(EMPTY_FORM);
+      setErrors([]);
+    }
+  }
+
+  return (
+    <div className="space-y-4 py-4">
+      {errors.length > 0 && (
+        <div className="text-sm text-destructive space-y-1">
+          {errors.map((e, i) => (
+            <p key={i}>{e}</p>
+          ))}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1">
+          <Label>Move Number</Label>
+          <Input
+            type="number"
+            min={1}
+            value={form.move_number}
+            onChange={(e) =>
+              setForm({
+                ...form,
+                move_number:
+                  e.target.value === "" ? "" : Number(e.target.value),
+              })
+            }
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label>Sequence</Label>
+          <Input
+            type="number"
+            min={1}
+            value={form.sequence}
+            onChange={(e) =>
+              setForm({
+                ...form,
+                sequence: e.target.value === "" ? "" : Number(e.target.value),
+              })
+            }
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1">
+          <Label>Stance</Label>
+          <Select
+            value={form.stance_id}
+            onValueChange={(v) => setForm({ ...form, stance_id: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select stance..." />
+            </SelectTrigger>
+            <SelectContent>
+              {stances.map((s) => (
+                <SelectItem key={s.id} value={String(s.id)}>
+                  {s.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label>Technique</Label>
+          <Select
+            value={form.technique_id}
+            onValueChange={(v) => setForm({ ...form, technique_id: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select technique..." />
+            </SelectTrigger>
+            <SelectContent>
+              {techniques.map((t) => (
+                <SelectItem key={t.id} value={String(t.id)}>
+                  {t.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1">
+          <Label>
+            Timing{" "}
+            <span className="text-muted-foreground text-xs">(optional)</span>
+          </Label>
+          <Select
+            value={form.timing}
+            onValueChange={(v) => setForm({ ...form, timing: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="None" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="NONE">None</SelectItem>
+              <SelectItem value="SIMULTANEOUS">Simultaneous</SelectItem>
+              <SelectItem value="SEQUENTIAL">Sequential</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label>Direction</Label>
+          <Select
+            value={form.direction}
+            onValueChange={(v) => setForm({ ...form, direction: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              {[
+                ["N", "North"],
+                ["S", "South"],
+                ["E", "East"],
+                ["W", "West"],
+                ["NE", "Northeast"],
+                ["NW", "Northwest"],
+                ["SE", "Southeast"],
+                ["SW", "Southwest"],
+              ].map(([v, l]) => (
+                <SelectItem key={v} value={v}>
+                  {l}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1">
+          <Label>Lead Foot</Label>
+          <Select
+            value={form.lead_foot}
+            onValueChange={(v) => setForm({ ...form, lead_foot: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="LEFT">Left</SelectItem>
+              <SelectItem value="RIGHT">Right</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label>Hip Position</Label>
+          <Select
+            value={form.hip}
+            onValueChange={(v) => setForm({ ...form, hip: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="HANMI">Hanmi</SelectItem>
+              <SelectItem value="SHOMEN">Shomen</SelectItem>
+              <SelectItem value="GYAKUHANMI">Gyaku Hanmi</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1">
+          <Label>Active Side</Label>
+          <Select
+            value={form.active_side}
+            onValueChange={(v) => setForm({ ...form, active_side: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="LEFT">Left</SelectItem>
+              <SelectItem value="RIGHT">Right</SelectItem>
+              <SelectItem value="BOTH">Both</SelectItem>
+              <SelectItem value="NEITHER">Neither</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label>Speed</Label>
+          <Select
+            value={form.speed}
+            onValueChange={(v) => setForm({ ...form, speed: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="FAST">Fast</SelectItem>
+              <SelectItem value="SLOW">Slow</SelectItem>
+              <SelectItem value="FAST_SLOW">Fast → Slow</SelectItem>
+              <SelectItem value="SLOW_FAST">Slow → Fast</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1">
+          <Label>Snap / Thrust</Label>
+          <Select
+            value={form.snap_thrust}
+            onValueChange={(v) => setForm({ ...form, snap_thrust: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="SNAP">Snap</SelectItem>
+              <SelectItem value="THRUST">Thrust</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label>Level</Label>
+          <Select
+            value={form.level}
+            onValueChange={(v) => setForm({ ...form, level: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="GEDAN">Gedan (Lower)</SelectItem>
+              <SelectItem value="CHUDAN">Chudan (Middle)</SelectItem>
+              <SelectItem value="JODAN">Jodan (Upper)</SelectItem>
+              <SelectItem value="GEDAN_JODAN">Gedan & Jodan</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="flex flex-col gap-1">
+          <Label>Breath</Label>
+          <Select
+            value={form.breath}
+            onValueChange={(v) => setForm({ ...form, breath: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="IN">Inhale</SelectItem>
+              <SelectItem value="OUT">Exhale</SelectItem>
+              <SelectItem value="IN_OUT">Inhale & Exhale</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label>Interm. Move</Label>
+          <Select
+            value={form.interm_move}
+            onValueChange={(v) => setForm({ ...form, interm_move: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="true">Yes</SelectItem>
+              <SelectItem value="false">No</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label>Kiai</Label>
+          <Select
+            value={form.kiai}
+            onValueChange={(v) => setForm({ ...form, kiai: v })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="true">Yes</SelectItem>
+              <SelectItem value="false">No</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <Button onClick={handleAdd}>Add to Queue</Button>
+    </div>
+  );
+}

--- a/app/kata-moves/upload/page.tsx
+++ b/app/kata-moves/upload/page.tsx
@@ -1,0 +1,16 @@
+import { getKatas } from "@/lib/actions/katas";
+import { getStances } from "@/lib/actions/stances";
+import { getTechniques } from "@/lib/actions/techniques";
+import { KataMovesUploadForm } from "./upload-form";
+
+export default async function UploadKataMovePage() {
+  const [katas, stances, techniques] = await Promise.all([
+    getKatas(),
+    getStances(),
+    getTechniques(),
+  ]);
+
+  return (
+    <KataMovesUploadForm katas={katas} stances={stances} techniques={techniques} />
+  )
+}

--- a/app/kata-moves/upload/upload-form.tsx
+++ b/app/kata-moves/upload/upload-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import type { Kata, Stance, Technique } from "@/app/generated/prisma/browser";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -20,6 +21,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { createMultipleMoves } from "@/lib/actions/kata-moves";
+import type { ValidatedMoveData } from "@/lib/validation/kata-moves";
+import { MoveForm } from "./manual-move-form";
 
 interface KataMovesProps {
   katas: Kata[];
@@ -32,6 +36,32 @@ export function KataMovesUploadForm({
   techniques,
 }: KataMovesProps) {
   const [selectedKataId, setSelectedKataId] = useState<number | null>(null);
+  const [queuedMoves, setQueuedMoves] = useState<ValidatedMoveData[]>([]);
+
+  const selectedKata = katas.find((kata) => kata.id === selectedKataId);
+
+  function addToQueue(move: ValidatedMoveData): boolean {
+    const conflict = queuedMoves.find(
+      (m) => m.move_number === move.move_number && m.sequence === move.sequence
+    );
+    if (conflict) {
+      toast.error(`Move ${move.move_number}, sequence ${move.sequence} is already in the queue`);
+      return false;
+    }
+    setQueuedMoves((prev) => [...prev, move]);
+    return true;
+  }
+
+  async function handleImport() {
+    if (!selectedKataId || queuedMoves.length === 0) return;
+    const result = await createMultipleMoves(selectedKataId, queuedMoves);
+    if (result.success) {
+      toast.success(`${result.createdCount} move(s) imported successfully`);
+      setQueuedMoves([]);
+    } else {
+      toast.error(result.error ?? "Failed to import moves");
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -63,7 +93,11 @@ export function KataMovesUploadForm({
           </TabsTrigger>
         </TabsList>
         <TabsContent value="manual">
-          <p>PLACEHOLDER</p>
+          <MoveForm
+            stances={stances}
+            techniques={techniques}
+            onAdd={addToQueue}
+          />
         </TabsContent>
         <TabsContent value="csv">
           <p>PLACEHOLDER</p>
@@ -73,8 +107,10 @@ export function KataMovesUploadForm({
       {/* Move queue */}
       <div className="space-y-2">
         <div className="flex items-center justify-between">
-          <h3 className="font-medium">Move Queue</h3>
-          <Button variant="ghost" size="sm">
+          <h3 className="font-medium">
+            Move Queue{selectedKata ? ` for: ${selectedKata.name}` : ""}
+          </h3>
+          <Button variant="ghost" size="sm" onClick={() => setQueuedMoves([])}>
             Clear Queue
           </Button>
         </div>
@@ -95,20 +131,57 @@ export function KataMovesUploadForm({
                 <TableHead>Snap/Thrust</TableHead>
                 <TableHead>Level</TableHead>
                 <TableHead>Breath</TableHead>
+                <TableHead>Interm Move</TableHead>
                 <TableHead>Kiai</TableHead>
                 <TableHead></TableHead>
               </TableRow>
             </TableHeader>
-            <TableBody>
-              <TableRow>
-                <TableCell colSpan={15}>
-                  PLACEHOLDER
-                </TableCell>
-              </TableRow>
-            </TableBody>
+              <TableBody>
+                {queuedMoves.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={16} className="text-muted-foreground italic">
+                      No moves queued yet.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  queuedMoves.map((move, i) => (
+                    <TableRow key={i}>
+                      <TableCell>{move.move_number}</TableCell>
+                      <TableCell>{move.sequence}</TableCell>
+                      <TableCell>{move.timing ?? "—"}</TableCell>
+                      <TableCell>{stances.find((s) => s.id === move.stance_id)?.name}</TableCell>
+                      <TableCell>{techniques.find((t) => t.id === move.technique_id)?.name}</TableCell>
+                      <TableCell>{move.direction}</TableCell>
+                      <TableCell>{move.lead_foot}</TableCell>
+                      <TableCell>{move.hip}</TableCell>
+                      <TableCell>{move.active_side}</TableCell>
+                      <TableCell>{move.speed}</TableCell>
+                      <TableCell>{move.snap_thrust}</TableCell>
+                      <TableCell>{move.level}</TableCell>
+                      <TableCell>{move.breath}</TableCell>
+                      <TableCell>{move.interm_move ? "Yes" : "No"}</TableCell>
+                      <TableCell>{move.kiai ? "Yes" : "No"}</TableCell>
+                      <TableCell>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setQueuedMoves((prev) => prev.filter((_, idx) => idx !== i))}
+                        >
+                          Remove
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
           </Table>
         </div>
-        <Button disabled>Import Moves</Button>
+        <Button
+          disabled={queuedMoves.length === 0 || !selectedKataId}
+          onClick={handleImport}
+        >
+          Import {queuedMoves.length} Move{queuedMoves.length !== 1 ? "s" : ""}
+        </Button>
       </div>
     </div>
   );

--- a/app/kata-moves/upload/upload-form.tsx
+++ b/app/kata-moves/upload/upload-form.tsx
@@ -22,7 +22,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { createMultipleMoves } from "@/lib/actions/kata-moves";
-import type { ValidatedMoveData } from "@/lib/validation/kata-moves";
+import type { MoveFormState, ValidatedMoveData } from "@/lib/validation/kata-moves";
+import { CsvUploadForm } from "./csv-upload-form";
 import { MoveForm } from "./manual-move-form";
 
 interface KataMovesProps {
@@ -37,6 +38,8 @@ export function KataMovesUploadForm({
 }: KataMovesProps) {
   const [selectedKataId, setSelectedKataId] = useState<number | null>(null);
   const [queuedMoves, setQueuedMoves] = useState<ValidatedMoveData[]>([]);
+  const [activeTab, setActiveTab] = useState("manual");
+  const [formInitialValues, setFormInitialValues] = useState<Partial<MoveFormState> | undefined>(undefined)
 
   const selectedKata = katas.find((kata) => kata.id === selectedKataId);
 
@@ -63,6 +66,15 @@ export function KataMovesUploadForm({
     }
   }
 
+  function handleReview(values: Partial<MoveFormState>) {
+    setFormInitialValues(values);
+    setActiveTab("manual");
+  }
+
+  function handleAddAll(moves: ValidatedMoveData[]) {
+    moves.forEach((move) => addToQueue(move));
+  }
+
   return (
     <div className="space-y-6">
       {/* Kata selector */}
@@ -83,7 +95,7 @@ export function KataMovesUploadForm({
       </div>
 
       {/* Tabs */}
-      <Tabs defaultValue="manual">
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>
           <TabsTrigger value="manual" disabled={!selectedKataId}>
             Manual Entry
@@ -96,11 +108,17 @@ export function KataMovesUploadForm({
           <MoveForm
             stances={stances}
             techniques={techniques}
+            initialValues={formInitialValues}
             onAdd={addToQueue}
           />
         </TabsContent>
         <TabsContent value="csv">
-          <p>PLACEHOLDER</p>
+          <CsvUploadForm
+            stances={stances}
+            techniques={techniques}
+            onReview={handleReview}
+            onAddAll={handleAddAll}
+          />
         </TabsContent>
       </Tabs>
 

--- a/app/kata-moves/upload/upload-form.tsx
+++ b/app/kata-moves/upload/upload-form.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import type { Kata, Stance, Technique } from "@/app/generated/prisma/browser";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface KataMovesProps {
+  katas: Kata[];
+  stances: Stance[];
+  techniques: Technique[];
+}
+export function KataMovesUploadForm({
+  katas,
+  stances,
+  techniques,
+}: KataMovesProps) {
+  const [selectedKataId, setSelectedKataId] = useState<number | null>(null);
+
+  return (
+    <div className="space-y-6">
+      {/* Kata selector */}
+      <div className="flex flex-col gap-2 max-w-sm">
+        <Label>Select a Kata</Label>
+        <Select onValueChange={(value) => setSelectedKataId(Number(value))}>
+          <SelectTrigger>
+            <SelectValue placeholder="Choose a kata..." />
+          </SelectTrigger>
+          <SelectContent>
+            {katas.map((kata) => (
+              <SelectItem key={kata.id} value={String(kata.id)}>
+                {kata.name} ({kata.style})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Tabs */}
+      <Tabs defaultValue="manual">
+        <TabsList>
+          <TabsTrigger value="manual" disabled={!selectedKataId}>
+            Manual Entry
+          </TabsTrigger>
+          <TabsTrigger value="csv" disabled={!selectedKataId}>
+            CSV Upload
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="manual">
+          <p>PLACEHOLDER</p>
+        </TabsContent>
+        <TabsContent value="csv">
+          <p>PLACEHOLDER</p>
+        </TabsContent>
+      </Tabs>
+
+      {/* Move queue */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="font-medium">Move Queue</h3>
+          <Button variant="ghost" size="sm">
+            Clear Queue
+          </Button>
+        </div>
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Move #</TableHead>
+                <TableHead>Seq</TableHead>
+                <TableHead>Timing</TableHead>
+                <TableHead>Stance</TableHead>
+                <TableHead>Technique</TableHead>
+                <TableHead>Direction</TableHead>
+                <TableHead>Lead Foot</TableHead>
+                <TableHead>Hip</TableHead>
+                <TableHead>Active Side</TableHead>
+                <TableHead>Speed</TableHead>
+                <TableHead>Snap/Thrust</TableHead>
+                <TableHead>Level</TableHead>
+                <TableHead>Breath</TableHead>
+                <TableHead>Kiai</TableHead>
+                <TableHead></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell colSpan={15}>
+                  PLACEHOLDER
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+        <Button disabled>Import Moves</Button>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
+        "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/lib/actions/kata-moves.ts
+++ b/lib/actions/kata-moves.ts
@@ -1,6 +1,8 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import prisma from "@/lib/prisma";
+import type { ValidatedMoveData } from "../validation/kata-moves";
 
 export async function getKataMoves() {
   try {
@@ -19,5 +21,84 @@ export async function getKataMoves() {
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to load moveset data");
+  }
+}
+
+interface ImportResult {
+  success: boolean;
+  error: string | null;
+  createdCount: number;
+  skippedCount: number;
+}
+
+export async function createMultipleMoves(
+  kataId: number,
+  moves: ValidatedMoveData[],
+): Promise<ImportResult> {
+  try {
+    const existingMoves = await prisma.move.findMany({
+      where: {
+        kata_id: kataId,
+        OR: moves.map((m) => ({
+          move_number: m.move_number,
+          sequence: m.sequence,
+        })),
+      },
+      select: { move_number: true, sequence: true },
+    });
+
+    if (existingMoves.length > 0) {
+      const duplicates = existingMoves
+        .map((m) => `move ${m.move_number} seq ${m.sequence}`)
+        .join(", ");
+      return {
+        success: false,
+        error: `The following moves already exist for this kata: ${duplicates}`,
+        createdCount: 0,
+        skippedCount: existingMoves.length,
+      };
+    }
+
+    const createdMoves = await prisma.$transaction(
+      moves.map((move) =>
+        prisma.move.create({
+          data: {
+            kata_id: kataId,
+            move_number: move.move_number,
+            sequence: move.sequence,
+            timing: move.timing ?? undefined,
+            stance_id: move.stance_id,
+            technique_id: move.technique_id,
+            direction: move.direction,
+            lead_foot: move.lead_foot,
+            hip: move.hip,
+            active_side: move.active_side,
+            speed: move.speed,
+            snap_thrust: move.snap_thrust,
+            level: move.level,
+            breath: move.breath,
+            interm_move: move.interm_move,
+            kiai: move.kiai,
+          },
+        }),
+      ),
+    );
+
+    revalidatePath("/kata-moves");
+
+    return {
+      success: true,
+      error: null,
+      createdCount: createdMoves.length,
+      skippedCount: 0,
+    };
+  } catch (error) {
+    console.error("Error importing moves:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to import moves",
+      createdCount: 0,
+      skippedCount: 0,
+    };
   }
 }

--- a/lib/validation/csv-kata-moves.ts
+++ b/lib/validation/csv-kata-moves.ts
@@ -1,19 +1,4 @@
-export interface ValidatedMoveData {
-  move_number: number
-  sequence: number
-  timing: "SIMULTANEOUS" | "SEQUENTIAL" | null
-  stance_id: number
-  technique_id: number
-  direction: "N" | "S" | "E" | "W" | "NE" | "NW" | "SE" | "SW"
-  lead_foot: "LEFT" | "RIGHT"
-  hip: "HANMI" | "SHOMEN" | "GYAKUHANMI"
-  active_side: "LEFT" | "RIGHT" | "BOTH" | "NEITHER"
-  speed: "FAST" | "SLOW" | "FAST_SLOW" | "SLOW_FAST"
-  snap_thrust: "SNAP" | "THRUST"
-  level: "GEDAN" | "CHUDAN" | "JODAN" | "GEDAN_JODAN"
-  breath: "IN" | "OUT" | "IN_OUT"
-  kiai: boolean
-}
+import type { ValidatedMoveData } from "./kata-moves"
 
 export interface MoveRow {
   move_number: string

--- a/lib/validation/csv-kata-moves.ts
+++ b/lib/validation/csv-kata-moves.ts
@@ -1,0 +1,157 @@
+export interface ValidatedMoveData {
+  move_number: number
+  sequence: number
+  timing: "SIMULTANEOUS" | "SEQUENTIAL" | null
+  stance_id: number
+  technique_id: number
+  direction: "N" | "S" | "E" | "W" | "NE" | "NW" | "SE" | "SW"
+  lead_foot: "LEFT" | "RIGHT"
+  hip: "HANMI" | "SHOMEN" | "GYAKUHANMI"
+  active_side: "LEFT" | "RIGHT" | "BOTH" | "NEITHER"
+  speed: "FAST" | "SLOW" | "FAST_SLOW" | "SLOW_FAST"
+  snap_thrust: "SNAP" | "THRUST"
+  level: "GEDAN" | "CHUDAN" | "JODAN" | "GEDAN_JODAN"
+  breath: "IN" | "OUT" | "IN_OUT"
+  kiai: boolean
+}
+
+export interface MoveRow {
+  move_number: string
+  sequence: string
+  timing: string
+  stance: string
+  technique: string
+  direction: string
+  lead_foot: string
+  hip: string
+  active_side: string
+  speed: string
+  snap_thrust: string
+  level: string
+  breath: string
+  interm_move: string
+  kiai: string
+}
+
+export interface ValidatedMoveRow {
+  data: ValidatedMoveData | null
+  rowNumber: number
+  isValid: boolean
+  errors: string[]
+}
+
+const VALID_DIRECTIONS = ["N", "S", "E", "W", "NE", "NW", "SE", "SW"] as const
+const VALID_LEAD_FOOT = ["LEFT", "RIGHT"] as const
+const VALID_HIP = ["HANMI", "SHOMEN", "GYAKUHANMI"] as const
+const VALID_ACTIVE_SIDE = ["LEFT", "RIGHT", "BOTH", "NEITHER"] as const
+const VALID_SPEED = ["FAST", "SLOW", "FAST_SLOW", "SLOW_FAST"] as const
+const VALID_SNAP_THRUST = ["SNAP", "THRUST"] as const
+const VALID_LEVEL = ["GEDAN", "CHUDAN", "JODAN", "GEDAN_JODAN"] as const
+const VALID_TIMING = ["SIMULTANEOUS", "SEQUENTIAL"] as const
+const VALID_BREATH = ["IN", "OUT", "IN_OUT"] as const
+
+export function validateMoveCsvRow(
+  row: MoveRow,
+  rowNumber: number,
+  stances: { id: number; name: string }[],
+  techniques: { id: number; name: string }[],
+): ValidatedMoveRow {
+  const errors: string[] = []
+
+  const move_number = parseInt(row.move_number, 10)
+  if (isNaN(move_number) || move_number < 1) errors.push("move_number must be a positive integer")
+
+  const sequence = row.sequence ? parseInt(row.sequence, 10) : 1
+  if (isNaN(sequence) || sequence < 1) errors.push("sequence must be a positive integer")
+
+  const timingRaw = row.timing?.trim().toUpperCase() || null
+  if (timingRaw && !VALID_TIMING.includes(timingRaw as typeof VALID_TIMING[number])) {
+    errors.push(`timing must be one of: ${VALID_TIMING.join(", ")}`)
+  }
+  const timing = (VALID_TIMING.includes(timingRaw as typeof VALID_TIMING[number]) ? timingRaw : null) as ValidatedMoveData["timing"]
+
+  const stance = stances.find((s) => s.name.toLowerCase() === row.stance?.trim().toLowerCase())
+  if (!stance) errors.push(`Stance "${row.stance}" not found`)
+
+  const technique = techniques.find((t) => t.name.toLowerCase() === row.technique?.trim().toLowerCase())
+  if (!technique) errors.push(`Technique "${row.technique}" not found`)
+
+  const direction = row.direction?.trim().toUpperCase()
+  if (!VALID_DIRECTIONS.includes(direction as typeof VALID_DIRECTIONS[number])) {
+    errors.push(`direction must be one of: ${VALID_DIRECTIONS.join(", ")}`)
+  }
+
+  const lead_foot = row.lead_foot?.trim().toUpperCase()
+  if (!VALID_LEAD_FOOT.includes(lead_foot as typeof VALID_LEAD_FOOT[number])) {
+    errors.push(`lead_foot must be one of: ${VALID_LEAD_FOOT.join(", ")}`)
+  }
+
+  const hip = row.hip?.trim().toUpperCase()
+  if (!VALID_HIP.includes(hip as typeof VALID_HIP[number])) {
+    errors.push(`hip must be one of: ${VALID_HIP.join(", ")}`)
+  }
+
+  const active_side = row.active_side?.trim().toUpperCase()
+  if (!VALID_ACTIVE_SIDE.includes(active_side as typeof VALID_ACTIVE_SIDE[number])) {
+    errors.push(`active_side must be one of: ${VALID_ACTIVE_SIDE.join(", ")}`)
+  }
+
+  const speed = row.speed?.trim().toUpperCase()
+  if (!VALID_SPEED.includes(speed as typeof VALID_SPEED[number])) {
+    errors.push(`speed must be one of: ${VALID_SPEED.join(", ")}`)
+  }
+
+  const snap_thrust = row.snap_thrust?.trim().toUpperCase()
+  if (!VALID_SNAP_THRUST.includes(snap_thrust as typeof VALID_SNAP_THRUST[number])) {
+    errors.push(`snap_thrust must be one of: ${VALID_SNAP_THRUST.join(", ")}`)
+  }
+
+  const level = row.level?.trim().toUpperCase()
+  if (!VALID_LEVEL.includes(level as typeof VALID_LEVEL[number])) {
+    errors.push(`level must be one of: ${VALID_LEVEL.join(", ")}`)
+  }
+
+  const breath = row.breath?.trim().toUpperCase()
+  if (!VALID_BREATH.includes(breath as typeof VALID_BREATH[number])) {
+    errors.push(`breath must be one of: ${VALID_BREATH.join(", ")}`)
+  }
+
+  const intermRaw = row.interm_move?.trim().toLowerCase()
+  if (!["true", "false", "yes", "no"].includes(intermRaw)) {
+    errors.push("interm_move must be true/false or yes/no")
+  }
+  const interm_move = intermRaw === "true" || intermRaw === "yes"
+
+  const kiaiRaw = row.kiai?.trim().toLowerCase()
+  if (!["true", "false", "yes", "no"].includes(kiaiRaw)) {
+    errors.push("kiai must be true/false or yes/no")
+  }
+  const kiai = kiaiRaw === "true" || kiaiRaw === "yes"
+
+  if (errors.length > 0) {
+    return { data: null, rowNumber, isValid: false, errors }
+  }
+
+  return {
+    data: {
+      move_number,
+      sequence,
+      timing,
+      stance_id: stance!.id,
+      technique_id: technique!.id,
+      direction: direction as ValidatedMoveData["direction"],
+      lead_foot: lead_foot as ValidatedMoveData["lead_foot"],
+      hip: hip as ValidatedMoveData["hip"],
+      active_side: active_side as ValidatedMoveData["active_side"],
+      speed: speed as ValidatedMoveData["speed"],
+      snap_thrust: snap_thrust as ValidatedMoveData["snap_thrust"],
+      level: level as ValidatedMoveData["level"],
+      breath: breath as ValidatedMoveData["breath"],
+      interm_move,
+      kiai,
+    },
+    rowNumber,
+    isValid: true,
+    errors: [],
+  }
+}

--- a/lib/validation/kata-moves.ts
+++ b/lib/validation/kata-moves.ts
@@ -1,0 +1,86 @@
+export interface ValidatedMoveData {
+  move_number: number
+  sequence: number
+  timing: "SIMULTANEOUS" | "SEQUENTIAL" | null
+  stance_id: number
+  technique_id: number
+  direction: "N" | "S" | "E" | "W" | "NE" | "NW" | "SE" | "SW"
+  lead_foot: "LEFT" | "RIGHT"
+  hip: "HANMI" | "SHOMEN" | "GYAKUHANMI"
+  active_side: "LEFT" | "RIGHT" | "BOTH" | "NEITHER"
+  speed: "FAST" | "SLOW" | "FAST_SLOW" | "SLOW_FAST"
+  snap_thrust: "SNAP" | "THRUST"
+  level: "GEDAN" | "CHUDAN" | "JODAN" | "GEDAN_JODAN"
+  breath: "IN" | "OUT" | "IN_OUT"
+  interm_move: boolean
+  kiai: boolean
+}
+
+export interface MoveFormState {
+  move_number: number | ""
+  sequence: number | ""
+  timing: string
+  stance_id: string
+  technique_id: string
+  direction: string
+  lead_foot: string
+  hip: string
+  active_side: string
+  speed: string
+  snap_thrust: string
+  level: string
+  breath: string
+  interm_move: string
+  kiai: string
+}
+
+// Validates a single move entry from the manual entry form before adding to the queue
+export function validateMoveForm(
+  form: MoveFormState,
+): { data: ValidatedMoveData | null; errors: string[] } {
+  const errors: string[] = []
+
+  const move_number = Number(form.move_number)
+  if (!form.move_number || isNaN(move_number) || move_number < 1)
+    errors.push("Move number must be a positive integer")
+
+  const sequence = Number(form.sequence)
+  if (!form.sequence || isNaN(sequence) || sequence < 1)
+    errors.push("Sequence must be a positive integer")
+
+  if (!form.stance_id) errors.push("Stance is required")
+  if (!form.technique_id) errors.push("Technique is required")
+  if (!form.direction) errors.push("Direction is required")
+  if (!form.lead_foot) errors.push("Lead foot is required")
+  if (!form.hip) errors.push("Hip position is required")
+  if (!form.active_side) errors.push("Active side is required")
+  if (!form.speed) errors.push("Speed is required")
+  if (!form.snap_thrust) errors.push("Snap/thrust is required")
+  if (!form.level) errors.push("Level is required")
+  if (!form.breath) errors.push("Breath is required")
+  if (!form.interm_move) errors.push("Interm. move is required")
+  if (!form.kiai) errors.push("Kiai is required")
+
+  if (errors.length > 0) return { data: null, errors }
+
+  return {
+    data: {
+      move_number,
+      sequence,
+      timing: (form.timing || null) as ValidatedMoveData["timing"],
+      stance_id: Number(form.stance_id),
+      technique_id: Number(form.technique_id),
+      direction: form.direction as ValidatedMoveData["direction"],
+      lead_foot: form.lead_foot as ValidatedMoveData["lead_foot"],
+      hip: form.hip as ValidatedMoveData["hip"],
+      active_side: form.active_side as ValidatedMoveData["active_side"],
+      speed: form.speed as ValidatedMoveData["speed"],
+      snap_thrust: form.snap_thrust as ValidatedMoveData["snap_thrust"],
+      level: form.level as ValidatedMoveData["level"],
+      breath: form.breath as ValidatedMoveData["breath"],
+      interm_move: form.interm_move === "true",
+      kiai: form.kiai === "true",
+    },
+    errors: [],
+  }
+}

--- a/lib/validation/kata-moves.ts
+++ b/lib/validation/kata-moves.ts
@@ -67,7 +67,7 @@ export function validateMoveForm(
     data: {
       move_number,
       sequence,
-      timing: (form.timing || null) as ValidatedMoveData["timing"],
+      timing: (form.timing === "NONE" || !form.timing ? null : form.timing) as ValidatedMoveData["timing"],
       stance_id: Number(form.stance_id),
       technique_id: Number(form.technique_id),
       direction: form.direction as ValidatedMoveData["direction"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
         "papaparse": "^5.5.3",
+        "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "sonner": "^2.0.7",
@@ -2034,6 +2035,60 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-accessible-icon": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
+      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-alert-dialog": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
@@ -2087,6 +2142,86 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2207,6 +2342,34 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dialog": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
@@ -2303,6 +2466,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -2327,6 +2519,88 @@
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2403,6 +2677,251 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
+      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
+      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2528,6 +3047,124 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
@@ -2635,6 +3272,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -2649,6 +3319,205 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-toggle-group": "1.1.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -2764,6 +3633,24 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -7875,6 +8762,147 @@
       ],
       "license": "MIT"
     },
+    "node_modules/radix-ui": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
+      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-accessible-icon": "1.1.7",
+        "@radix-ui/react-accordion": "1.2.12",
+        "@radix-ui/react-alert-dialog": "1.1.15",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-aspect-ratio": "1.1.7",
+        "@radix-ui/react-avatar": "1.1.10",
+        "@radix-ui/react-checkbox": "1.3.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-context-menu": "2.2.16",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-dropdown-menu": "2.1.16",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-form": "0.1.8",
+        "@radix-ui/react-hover-card": "1.1.15",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-menubar": "1.1.16",
+        "@radix-ui/react-navigation-menu": "1.2.14",
+        "@radix-ui/react-one-time-password-field": "0.1.8",
+        "@radix-ui/react-password-toggle-field": "0.1.3",
+        "@radix-ui/react-popover": "1.1.15",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-progress": "1.1.7",
+        "@radix-ui/react-radio-group": "1.3.8",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-scroll-area": "1.2.10",
+        "@radix-ui/react-select": "2.2.6",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-slider": "1.3.6",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-switch": "1.2.6",
+        "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-toast": "1.2.15",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-toggle-group": "1.1.11",
+        "@radix-ui/react-toolbar": "1.1.11",
+        "@radix-ui/react-tooltip": "1.2.8",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rc9": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
@@ -9151,6 +10179,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/valibot": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "papaparse": "^5.5.3",
+    "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "sonner": "^2.0.7",


### PR DESCRIPTION
- Adds `/kata-moves/upload` page where the user must select a kata, then builds a move queue via manual entry or CSV upload before batch-importing
- Manual entry form validates each move and adds it to a staging queue. Duplicate (move_number, sequence) pairs are blocked with a toast error
- CSV upload parses and validates rows against DB stances/techniques; individual rows can be sent to the manual form for review/editing before queuing, or all valid rows added at once
- createMultipleMoves server action checks for DB-level duplicates and inserts as an atomic transaction
<img width="1033" height="992" alt="image" src="https://github.com/user-attachments/assets/4b98248f-4cb3-440f-940f-debc76b6c837" />
<img width="1027" height="989" alt="image" src="https://github.com/user-attachments/assets/5a0a4caa-6d80-40da-8953-c2533328f388" />

