### PR TITLE
Fix stale dropdown data in kata-moves upload page

### DIFF
--- a/lib/actions/csv-upload.ts
+++ b/lib/actions/csv-upload.ts
@@ -54,6 +54,7 @@ export async function importKatasAction(
     );
 
     revalidatePath("/katas");
+    revalidatePath("/kata-moves/upload");
 
     return {
       success: true,
@@ -105,6 +106,7 @@ export async function importStancesAction(
     );
 
     revalidatePath("/stances");
+    revalidatePath("/kata-moves/upload");
 
     return {
       success: true,
@@ -159,7 +161,8 @@ export async function importTechniquesAction(
     );
 
     revalidatePath("/techniques");
-
+    revalidatePath("/kata-moves/upload");
+    
     return {
       success: true,
       error: null,

--- a/lib/actions/katas.ts
+++ b/lib/actions/katas.ts
@@ -58,6 +58,7 @@ export async function createKataAction(
   try {
     const kata = await createKata(formData);
     revalidatePath("/katas");
+    revalidatePath("/kata-moves/upload");
     return {
       success: true,
       error: null,
@@ -140,6 +141,7 @@ export async function updateKataAction(
 
     const kata = await updateKata(id, formData);
     revalidatePath("/katas");
+    revalidatePath("/kata-moves/upload");
     return {
       success: true,
       error: null,
@@ -162,6 +164,7 @@ export async function deleteKata(id: number) {
       where: { id },
     });
     revalidatePath("/katas");
+    revalidatePath("/kata-moves/upload");
     return deletedKata;
   } catch (error) {
     console.error("Database error", error);

--- a/lib/actions/stances.ts
+++ b/lib/actions/stances.ts
@@ -56,6 +56,7 @@ export async function createStanceAction(
   try {
     const stance = await createStance(formData);
     revalidatePath("/stances");
+    revalidatePath("/kata-moves/upload");
     return {
       success: true,
       error: null,
@@ -132,6 +133,7 @@ export async function updateStanceAction(
 
     const stance = await updateStance(id, formData);
     revalidatePath("/stances");
+    revalidatePath("/kata-moves/upload");
     return {
       success: true,
       error: null,
@@ -154,6 +156,7 @@ export async function deleteStance(id: number) {
       where: { id },
     });
     revalidatePath("/stances");
+    revalidatePath("/kata-moves/upload");
     return deletedStance;
   } catch (error) {
     console.error("Database error", error);

--- a/lib/actions/techniques.ts
+++ b/lib/actions/techniques.ts
@@ -59,6 +59,7 @@ export async function createTechniqueAction(
   try {
     const technique = await createTechnique(formData);
     revalidatePath("/techniques");
+    revalidatePath("/kata-moves/upload");
     return {
       success: true,
       error: null,
@@ -141,6 +142,7 @@ export async function updateTechniqueAction(
 
     const technique = await updateTechnique(id, formData);
     revalidatePath("/techniques");
+    revalidatePath("/kata-moves/upload");
     return {
       success: true,
       error: null,
@@ -164,6 +166,7 @@ export async function deleteTechnique(id: number) {
     });
 
     revalidatePath("/techniques");
+    revalidatePath("/kata-moves/upload");
     return deletedTechnique;
   } catch (error) {
     console.error("Database error", error);


### PR DESCRIPTION
- Add `revalidatePath("/kata-moves/upload")` to `lib/actions/kata.ts`, `lib/actions/stance.ts`, `lib/actions/technique.ts` and `lib/actions/csv-upload.ts` to CRUD actions to clear cache when data changes.
- Prevents dropdowns in `/kata-moves/upload/page.tsx` from showing outdated entries