### PR TITLE
Refactor hardcoded enums to `lib/enum-labels`

### DIFF
--- a/app/kata-moves/edit/edit-move-sheet.tsx
+++ b/app/kata-moves/edit/edit-move-sheet.tsx
@@ -38,15 +38,15 @@ import {
   type MoveFormState,
 } from "@/lib/validation/kata-moves";
 import {
-  DirectionLabel,
-  LeadFootLabel,
-  HipPositionLabel,
   ActiveSideLabel,
-  SpeedLabel,
-  SnapThrustLabel,
-  TechniqueLevelLabel,
   BreathLabel,
+  DirectionLabel,
+  HipPositionLabel,
+  LeadFootLabel,
   MoveTimingLabel,
+  SnapThrustLabel,
+  SpeedLabel,
+  TechniqueLevelLabel,
   toFilterOptions,
 } from "@/lib/enum-labels";
 

--- a/app/kata-moves/edit/edit-move-sheet.tsx
+++ b/app/kata-moves/edit/edit-move-sheet.tsx
@@ -37,6 +37,18 @@ import {
   validateMoveForm,
   type MoveFormState,
 } from "@/lib/validation/kata-moves";
+import {
+  DirectionLabel,
+  LeadFootLabel,
+  HipPositionLabel,
+  ActiveSideLabel,
+  SpeedLabel,
+  SnapThrustLabel,
+  TechniqueLevelLabel,
+  BreathLabel,
+  MoveTimingLabel,
+  toFilterOptions,
+} from "@/lib/enum-labels";
 
 interface EditMoveSheetProps {
   move: MoveWithRelations | null;
@@ -257,8 +269,9 @@ export function EditMoveSheet({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="NONE">None</SelectItem>
-                    <SelectItem value="SIMULTANEOUS">Simultaneous</SelectItem>
-                    <SelectItem value="SEQUENTIAL">Sequential</SelectItem>
+                    {toFilterOptions(MoveTimingLabel).map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -274,19 +287,8 @@ export function EditMoveSheet({
                     <SelectValue placeholder="Select..." />
                   </SelectTrigger>
                   <SelectContent>
-                    {[
-                      ["N", "North"],
-                      ["S", "South"],
-                      ["E", "East"],
-                      ["W", "West"],
-                      ["NE", "Northeast"],
-                      ["NW", "Northwest"],
-                      ["SE", "Southeast"],
-                      ["SW", "Southwest"],
-                    ].map(([v, l]) => (
-                      <SelectItem key={v} value={v}>
-                        {l}
-                      </SelectItem>
+                    {toFilterOptions(DirectionLabel).map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
@@ -307,8 +309,9 @@ export function EditMoveSheet({
                     <SelectValue placeholder="Select..." />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="LEFT">Left</SelectItem>
-                    <SelectItem value="RIGHT">Right</SelectItem>
+                    {toFilterOptions(LeadFootLabel).map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -322,9 +325,9 @@ export function EditMoveSheet({
                     <SelectValue placeholder="Select..." />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="HANMI">Hanmi</SelectItem>
-                    <SelectItem value="SHOMEN">Shomen</SelectItem>
-                    <SelectItem value="GYAKUHANMI">Gyaku Hanmi</SelectItem>
+                    {toFilterOptions(HipPositionLabel).map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -344,10 +347,9 @@ export function EditMoveSheet({
                     <SelectValue placeholder="Select..." />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="LEFT">Left</SelectItem>
-                    <SelectItem value="RIGHT">Right</SelectItem>
-                    <SelectItem value="BOTH">Both</SelectItem>
-                    <SelectItem value="NEITHER">Neither</SelectItem>
+                    {toFilterOptions(ActiveSideLabel).map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -363,10 +365,9 @@ export function EditMoveSheet({
                     <SelectValue placeholder="Select..." />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="FAST">Fast</SelectItem>
-                    <SelectItem value="SLOW">Slow</SelectItem>
-                    <SelectItem value="FAST_SLOW">Fast → Slow</SelectItem>
-                    <SelectItem value="SLOW_FAST">Slow → Fast</SelectItem>
+                    {toFilterOptions(SpeedLabel).map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -386,8 +387,9 @@ export function EditMoveSheet({
                     <SelectValue placeholder="Select..." />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="SNAP">Snap</SelectItem>
-                    <SelectItem value="THRUST">Thrust</SelectItem>
+                    {toFilterOptions(SnapThrustLabel).map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -403,10 +405,9 @@ export function EditMoveSheet({
                     <SelectValue placeholder="Select..." />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="GEDAN">Gedan (Lower)</SelectItem>
-                    <SelectItem value="CHUDAN">Chudan (Middle)</SelectItem>
-                    <SelectItem value="JODAN">Jodan (Upper)</SelectItem>
-                    <SelectItem value="GEDAN_JODAN">Gedan & Jodan</SelectItem>
+                    {toFilterOptions(TechniqueLevelLabel).map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -426,9 +427,9 @@ export function EditMoveSheet({
                     <SelectValue placeholder="Select..." />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="IN">Inhale</SelectItem>
-                    <SelectItem value="OUT">Exhale</SelectItem>
-                    <SelectItem value="IN_OUT">Inhale & Exhale</SelectItem>
+                    {toFilterOptions(BreathLabel).map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/app/kata-moves/kata-moves-data-table.tsx
+++ b/app/kata-moves/kata-moves-data-table.tsx
@@ -36,6 +36,19 @@ import {
 } from "@/components/ui/table";
 
 import type { MoveWithRelations } from "./columns";
+import {
+  TechniqueTypeLabel,
+  MoveTimingLabel,
+  DirectionLabel,
+  LeadFootLabel,
+  HipPositionLabel,
+  ActiveSideLabel,
+  SpeedLabel,
+  SnapThrustLabel,
+  TechniqueLevelLabel,
+  BreathLabel,
+  toFilterOptions,
+} from "@/lib/enum-labels";
 
 interface KataMovesDataTableProps {
   columns: ColumnDef<MoveWithRelations, unknown>[];
@@ -44,63 +57,16 @@ interface KataMovesDataTableProps {
 
 type FilterOption = { value: string; label: string };
 
-const techniqueTypeOptions: FilterOption[] = [
-  { value: "BLOCK", label: "Block" },
-  { value: "PUNCH", label: "Punch" },
-  { value: "KICK", label: "Kick" },
-  { value: "STRIKE", label: "Strike" },
-  { value: "PREP", label: "Prep" },
-];
-const timingOptions: FilterOption[] = [
-  { value: "SIMULTANEOUS", label: "Simultaneous" },
-  { value: "SEQUENTIAL", label: "Sequential" },
-];
-const directionOptions: FilterOption[] = [
-  { value: "N", label: "North" },
-  { value: "S", label: "South" },
-  { value: "E", label: "East" },
-  { value: "W", label: "West" },
-  { value: "NE", label: "Northeast" },
-  { value: "NW", label: "Northwest" },
-  { value: "SE", label: "Southeast" },
-  { value: "SW", label: "Southwest" },
-];
-const techniqueLevelOptions: FilterOption[] = [
-  { value: "GEDAN", label: "Gedan (Lower)" },
-  { value: "CHUDAN", label: "Chudan (Middle)" },
-  { value: "JODAN", label: "Jodan (Upper)" },
-  { value: "GEDAN_JODAN", label: "Gedan & Jodan" },
-];
-const leadFootOptions: FilterOption[] = [
-  { value: "LEFT", label: "Left" },
-  { value: "RIGHT", label: "Right" },
-];
-const hipOptions: FilterOption[] = [
-  { value: "HANMI", label: "Hanmi" },
-  { value: "SHOMEN", label: "Shomen" },
-  { value: "GYAKUHANMI", label: "Gyaku Hanmi" },
-];
-const activeSideOptions: FilterOption[] = [
-  { value: "LEFT", label: "Left" },
-  { value: "RIGHT", label: "Right" },
-  { value: "BOTH", label: "Both" },
-  { value: "NEITHER", label: "Neither" },
-];
-const speedOptions: FilterOption[] = [
-  { value: "FAST", label: "Fast" },
-  { value: "SLOW", label: "Slow" },
-  { value: "FAST_SLOW", label: "Fast → Slow" },
-  { value: "SLOW_FAST", label: "Slow → Fast" },
-];
-const snapThrustOptions: FilterOption[] = [
-  { value: "SNAP", label: "Snap" },
-  { value: "THRUST", label: "Thrust" },
-];
-const breathOptions: FilterOption[] = [
-  { value: "IN", label: "Inhale" },
-  { value: "OUT", label: "Exhale" },
-  { value: "IN_OUT", label: "In → Out" },
-];
+const techniqueTypeOptions = toFilterOptions(TechniqueTypeLabel);
+const timingOptions = toFilterOptions(MoveTimingLabel);
+const directionOptions = toFilterOptions(DirectionLabel);
+const techniqueLevelOptions = toFilterOptions(TechniqueLevelLabel);
+const leadFootOptions = toFilterOptions(LeadFootLabel);
+const hipOptions = toFilterOptions(HipPositionLabel);
+const activeSideOptions = toFilterOptions(ActiveSideLabel);
+const speedOptions = toFilterOptions(SpeedLabel);
+const snapThrustOptions = toFilterOptions(SnapThrustLabel);
+const breathOptions = toFilterOptions(BreathLabel);
 
 function ColumnFilter({
   table,

--- a/app/kata-moves/kata-moves-data-table.tsx
+++ b/app/kata-moves/kata-moves-data-table.tsx
@@ -37,16 +37,16 @@ import {
 
 import type { MoveWithRelations } from "./columns";
 import {
-  TechniqueTypeLabel,
-  MoveTimingLabel,
-  DirectionLabel,
-  LeadFootLabel,
-  HipPositionLabel,
   ActiveSideLabel,
-  SpeedLabel,
-  SnapThrustLabel,
-  TechniqueLevelLabel,
   BreathLabel,
+  DirectionLabel,
+  HipPositionLabel,
+  LeadFootLabel,
+  MoveTimingLabel,
+  SnapThrustLabel,
+  SpeedLabel,
+  TechniqueLevelLabel,
+  TechniqueTypeLabel,
   toFilterOptions,
 } from "@/lib/enum-labels";
 

--- a/app/kata-moves/upload/manual-move-form.tsx
+++ b/app/kata-moves/upload/manual-move-form.tsx
@@ -13,6 +13,18 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  ActiveSideLabel,
+  BreathLabel,
+  DirectionLabel,
+  HipPositionLabel,
+  LeadFootLabel,
+  MoveTimingLabel,
+  SnapThrustLabel,
+  SpeedLabel,
+  TechniqueLevelLabel,
+  toFilterOptions,
+} from "@/lib/enum-labels";
+import {
   validateMoveForm,
   type MoveFormState,
   type ValidatedMoveData,
@@ -164,8 +176,9 @@ export function MoveForm({ stances, techniques, initialValues, onAdd }: Props) {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="NONE">None</SelectItem>
-              <SelectItem value="SIMULTANEOUS">Simultaneous</SelectItem>
-              <SelectItem value="SEQUENTIAL">Sequential</SelectItem>
+              {toFilterOptions(MoveTimingLabel).map(({ value, label }) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -179,19 +192,8 @@ export function MoveForm({ stances, techniques, initialValues, onAdd }: Props) {
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              {[
-                ["N", "North"],
-                ["S", "South"],
-                ["E", "East"],
-                ["W", "West"],
-                ["NE", "Northeast"],
-                ["NW", "Northwest"],
-                ["SE", "Southeast"],
-                ["SW", "Southwest"],
-              ].map(([v, l]) => (
-                <SelectItem key={v} value={v}>
-                  {l}
-                </SelectItem>
+              {toFilterOptions(DirectionLabel).map(({ value, label }) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
               ))}
             </SelectContent>
           </Select>
@@ -209,8 +211,9 @@ export function MoveForm({ stances, techniques, initialValues, onAdd }: Props) {
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="LEFT">Left</SelectItem>
-              <SelectItem value="RIGHT">Right</SelectItem>
+              {toFilterOptions(LeadFootLabel).map(({ value, label }) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -224,9 +227,9 @@ export function MoveForm({ stances, techniques, initialValues, onAdd }: Props) {
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="HANMI">Hanmi</SelectItem>
-              <SelectItem value="SHOMEN">Shomen</SelectItem>
-              <SelectItem value="GYAKUHANMI">Gyaku Hanmi</SelectItem>
+              {toFilterOptions(HipPositionLabel).map(({ value, label }) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -243,10 +246,9 @@ export function MoveForm({ stances, techniques, initialValues, onAdd }: Props) {
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="LEFT">Left</SelectItem>
-              <SelectItem value="RIGHT">Right</SelectItem>
-              <SelectItem value="BOTH">Both</SelectItem>
-              <SelectItem value="NEITHER">Neither</SelectItem>
+              {toFilterOptions(ActiveSideLabel).map(({ value, label }) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -260,10 +262,9 @@ export function MoveForm({ stances, techniques, initialValues, onAdd }: Props) {
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="FAST">Fast</SelectItem>
-              <SelectItem value="SLOW">Slow</SelectItem>
-              <SelectItem value="FAST_SLOW">Fast → Slow</SelectItem>
-              <SelectItem value="SLOW_FAST">Slow → Fast</SelectItem>
+              {toFilterOptions(SpeedLabel).map(({ value, label }) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -280,8 +281,9 @@ export function MoveForm({ stances, techniques, initialValues, onAdd }: Props) {
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="SNAP">Snap</SelectItem>
-              <SelectItem value="THRUST">Thrust</SelectItem>
+              {toFilterOptions(SnapThrustLabel).map(({ value, label }) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -295,10 +297,9 @@ export function MoveForm({ stances, techniques, initialValues, onAdd }: Props) {
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="GEDAN">Gedan (Lower)</SelectItem>
-              <SelectItem value="CHUDAN">Chudan (Middle)</SelectItem>
-              <SelectItem value="JODAN">Jodan (Upper)</SelectItem>
-              <SelectItem value="GEDAN_JODAN">Gedan & Jodan</SelectItem>
+              {toFilterOptions(TechniqueLevelLabel).map(({ value, label }) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -315,9 +316,9 @@ export function MoveForm({ stances, techniques, initialValues, onAdd }: Props) {
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="IN">Inhale</SelectItem>
-              <SelectItem value="OUT">Exhale</SelectItem>
-              <SelectItem value="IN_OUT">Inhale & Exhale</SelectItem>
+              {toFilterOptions(BreathLabel).map(({ value, label }) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/lib/enum-labels.ts
+++ b/lib/enum-labels.ts
@@ -1,0 +1,90 @@
+import type {
+  TechniqueType,
+  MoveTiming,
+  Direction,
+  LeadFoot,
+  HipPosition,
+  ActiveSide,
+  Speed,
+  SnapThrust,
+  TechniqueLevel,
+  Breath,
+} from "@/app/generated/prisma/browser";
+
+// Converts a record of enum labels to an array of filter options for use in dropdowns or select components.
+export function toFilterOptions<T extends string>(
+  labels: Record<T, string>,
+): { value: string; label: string }[] {
+  return (Object.entries(labels) as [T, string][]).map(([value, label]) => ({
+    value,
+    label,
+  }));
+}
+
+export const TechniqueTypeLabel: Record<TechniqueType, string> = {
+  BLOCK: "Block",
+  PUNCH: "Punch",
+  KICK: "Kick",
+  STRIKE: "Strike",
+  PREP: "Prep",
+};
+
+export const MoveTimingLabel: Record<MoveTiming, string> = {
+  SIMULTANEOUS: "Simultaneous",
+  SEQUENTIAL: "Sequential",
+};
+
+export const DirectionLabel: Record<Direction, string> = {
+  N: "North",
+  S: "South",
+  E: "East",
+  W: "West",
+  NE: "Northeast",
+  NW: "Northwest",
+  SE: "Southeast",
+  SW: "Southwest",
+};
+
+export const LeadFootLabel: Record<LeadFoot, string> = {
+  LEFT: "Left",
+  RIGHT: "Right",
+  NEITHER: "Neither",
+};
+
+export const HipPositionLabel: Record<HipPosition, string> = {
+  HANMI: "Hanmi",
+  SHOMEN: "Shomen",
+  GYAKUHANMI: "Gyaku Hanmi",
+};
+
+export const ActiveSideLabel: Record<ActiveSide, string> = {
+  LEFT: "Left",
+  RIGHT: "Right",
+  BOTH: "Both",
+  NEITHER: "Neither",
+};
+
+export const SpeedLabel: Record<Speed, string> = {
+  FAST: "Fast",
+  SLOW: "Slow",
+  FAST_SLOW: "Fast → Slow",
+  SLOW_FAST: "Slow → Fast",
+};
+
+export const SnapThrustLabel: Record<SnapThrust, string> = {
+  SNAP: "Snap",
+  THRUST: "Thrust",
+};
+
+export const TechniqueLevelLabel: Record<TechniqueLevel, string> = {
+  GEDAN: "Gedan (Lower)",
+  CHUDAN: "Chudan (Middle)",
+  JODAN: "Jodan (Upper)",
+  GEDAN_JODAN: "Gedan & Jodan",
+};
+
+export const BreathLabel: Record<Breath, string> = {
+  IN: "Inhale",
+  OUT: "Exhale",
+  IN_OUT: "In → Out",
+};

--- a/prisma/migrations/20260313061854_add_leadfoot_neither_value/migration.sql
+++ b/prisma/migrations/20260313061854_add_leadfoot_neither_value/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "LeadFoot" ADD VALUE 'NEITHER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,7 @@ enum Direction {
 enum LeadFoot {
   LEFT
   RIGHT
+  NEITHER
 }
 
 enum HipPosition {


### PR DESCRIPTION
## Problem
Enum values were hard-coded within `app/kata-moves/edit/edit-move-sheet.tsx` and `app/kata-moves/kata-moves-data-table.tsx` despite having access to them in `app/generated/prisma/enums.ts`. 

## Solution
A new `lib/enum-labels.ts` file was created to store human-readable display labels for each Prisma enum used in the Move model. Each enum is mapped with `Record<EnumType, string>`. 
A `toFilterOptions()` helper function converts label maps into value, label arrays for use in dropdowns and fiilter selects.